### PR TITLE
streamable-http SSE 응답 라우팅

### DIFF
--- a/docs/LARGE-RESPONSE-ARCHITECTURE.md
+++ b/docs/LARGE-RESPONSE-ARCHITECTURE.md
@@ -160,7 +160,7 @@ data: {"type": "complete", "total_chunks": 15}
 - [ ] Benchmark compression ratios
 
 ### Phase 4 (Long-term)
-- [ ] SSE streaming for HTTP mode
+- [x] SSE streaming for HTTP mode
 - [ ] WebSocket support consideration
 - [ ] Client-side progressive rendering
 


### PR DESCRIPTION
## 변경 사항\n- streamable-http SSE 연결에 응답 메시지 라우팅 (POST는 202 반환, SSE로 message 전송)\n- SSE 데이터 라인 포맷 보정 및 shutdown 이벤트 정리\n- LLM 재시도는 retryable 오류만 재시도\n- SplitStream include 플래그 비활성 시 에러 청크 반환\n- 문서: HTTP SSE 스트리밍 완료 표시\n\n## 테스트\n- DUNE_CACHE=disabled dune build --root /Users/dancer/me/workspace/yousleepwhen/figma-mcp/.worktrees/fix-streamable-http-121\n