### PR TITLE
ci: 릴리즈 워크플로 불필요 pin 제거

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,8 @@ jobs:
         with:
           ocaml-compiler: 5.2.x
 
-      - name: Pin private dependencies
+      - name: Pin git dependencies
         run: |
-          opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-ocaml.git#main -n -y
           opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
 
       - name: Install dependencies


### PR DESCRIPTION
## 배경
- v0.3.4 릴리즈 워크플로가 "Pin private dependencies" 단계에서 실패함
- 실패 원인: mcp_protocol 핀이 GitHub Actions에서 인증 없이 private repo에 접근

## 변경
- release.yml에서 불필요한 pin 제거
  - compact-protocol pin 제거
  - mcp_protocol pin 제거
- grpc-direct-core pin만 유지

## 근거
- dune-project 의존성에 mcp_protocol/compact-protocol이 없음
- CHANGELOG에도 외부 mcp_protocol 제거가 기록됨

## 기대 효과
- 태그 푸시 기반 Release 워크플로 인증 실패 해소
