### PR TITLE
ci: fix grpc-direct pin missing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Pin git dependencies
         run: |
           opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
+          opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Release workflow의 `opam install` 단계에서 exit code 20 (dependency resolution failure)이 발생하는 문제 수정
- `grpc-direct-core`만 pin하고 `grpc-direct`는 pin하지 않아서 발생한 문제

## Changes
- `grpc-direct`도 함께 pin하도록 워크플로우 수정

## Test plan
- [ ] 새 태그 생성하여 릴리즈 워크플로우 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)