### PR TITLE
캐시 디렉토리 생성 안정화

### DIFF
--- a/lib/figma_cache.ml
+++ b/lib/figma_cache.ml
@@ -28,9 +28,16 @@ let make_cache_key ~file_key ~node_id ~options =
 
 (** 파일 시스템 유틸리티 *)
 module FS = struct
+  let rec mkdir_p path =
+    if not (Sys.file_exists path) then begin
+      let parent = Filename.dirname path in
+      if parent <> path then mkdir_p parent;
+      Unix.mkdir path 0o755
+    end
+
   let ensure_dir path =
     if not (Sys.file_exists path) then
-      Unix.mkdir path 0o755
+      mkdir_p path
 
   let read_file path =
     if Sys.file_exists path then


### PR DESCRIPTION
## 요약\n- 캐시 디렉토리 생성 시 부모 경로가 없을 경우 mkdir_p로 보강\n\n## 테스트\n- dune exec ./test/test_cache_early_stop.exe