### PR TITLE
fix: MCP tools error handling & large result preview (#26)

### DIFF
--- a/lib/large_response.ml
+++ b/lib/large_response.ml
@@ -86,6 +86,10 @@ let handle_response ~prefix ~format content : Yojson.Safe.t =
   else begin
     (* 큰 응답: 파일로 저장하고 메타데이터 반환 *)
     let filepath = save_to_file ~prefix content in
+    (* Include first 2KB as preview for immediate context *)
+    let preview_size = min 2048 size in
+    let preview = String.sub content 0 preview_size in
+    let preview_truncated = if size > preview_size then preview ^ "\n... [truncated]" else preview in
     `Assoc [
       ("status", `String "large_result");
       ("file_path", `String filepath);
@@ -93,7 +97,16 @@ let handle_response ~prefix ~format content : Yojson.Safe.t =
       ("size_human", `String (human_size size));
       ("format", `String format);
       ("ttl_seconds", `Int response_ttl);
+      ("preview", `String preview_truncated);
       ("hint", `String "Use figma_read_large_result with offset/limit, or figma_get_node_summary for lightweight structure");
+      ("next_chunk", `Assoc [
+        ("tool", `String "figma_read_large_result");
+        ("args", `Assoc [
+          ("file_path", `String filepath);
+          ("offset", `Int preview_size);
+          ("limit", `Int 10000);
+        ]);
+      ]);
       ("examples", `Assoc [
         ("read_first_1000_chars", `String (sprintf "head -c 1000 %s" filepath));
         ("read_with_jq", `String (sprintf "jq '.children[:5]' %s" filepath));
@@ -115,9 +128,13 @@ let wrap_string_result ~prefix ~format (content : string) : Yojson.Safe.t =
     text_content content
   else begin
     let filepath = save_to_file ~prefix content in
+    (* Include first 2KB as preview *)
+    let preview_size = min 2048 size in
+    let preview = String.sub content 0 preview_size in
+    let preview_truncated = if size > preview_size then preview ^ "\n... [truncated]" else preview in
     let message = sprintf
-      "Large result saved to %s (%s). Use figma_read_large_result or chunked loading."
-      filepath (human_size size)
+      "Large result saved to %s (%s). Preview below, use figma_read_large_result for more.\n\n%s"
+      filepath (human_size size) preview_truncated
     in
     add_meta (text_content message) [
       ("status", `String "large_result");
@@ -125,6 +142,15 @@ let wrap_string_result ~prefix ~format (content : string) : Yojson.Safe.t =
       ("size_bytes", `Int size);
       ("size_human", `String (human_size size));
       ("format", `String format);
+      ("preview_bytes", `Int preview_size);
+      ("next_chunk", `Assoc [
+        ("tool", `String "figma_read_large_result");
+        ("args", `Assoc [
+          ("file_path", `String filepath);
+          ("offset", `Int preview_size);
+          ("limit", `Int 10000);
+        ]);
+      ]);
       ("hint", `String "Content saved to file. Use figma_read_large_result or figma_get_node_chunk for progressive loading.");
     ]
   end

--- a/lib/mcp_tools.ml
+++ b/lib/mcp_tools.ml
@@ -2248,14 +2248,18 @@ let handle_get_node_bundle args : (Yojson.Safe.t, string) result =
                  (match find_node_entry nodes_map ~node_id with
                   | Some (node_key, node_entry) ->
                       (match member "document" node_entry with
-                       | Some doc -> Some (node_key, doc)
-                       | None -> None)
-                  | None -> None)
-             | _ -> None
+                       | Some doc -> Ok (node_key, doc)
+                       | None -> Error (sprintf "Node %s found but document is null" node_id))
+                  | None -> 
+                      let keys = List.map fst nodes_map in
+                      let keys_str = if keys = [] then "none" else String.concat ", " keys in
+                      Error (sprintf "Node %s not found. Available: [%s]" node_id keys_str))
+             | Some _ -> Error "API returned nodes in unexpected format"
+             | None -> Error "API response missing 'nodes' field"
            in
            (match node_lookup with
-            | None -> Error (sprintf "Node not found: %s" node_id)
-            | Some (node_key, node) ->
+            | Error msg -> Error msg
+            | Ok (node_key, node) ->
                 let node_str = Yojson.Safe.to_string node in
                 let dsl_str = match process_json_string ~format node_str with
                   | Ok s -> s
@@ -2515,7 +2519,13 @@ let handle_get_node_summary args : (Yojson.Safe.t, string) result =
              | None -> None
            in
            (match node_data with
-            | None -> Error (Printf.sprintf "Node %s not found in file %s" node_id file_key)
+            | None ->
+                (* Better error message with available keys *)
+                let available_keys = List.map fst nodes_map in
+                let keys_str = if available_keys = [] then "none" 
+                  else String.concat ", " available_keys in
+                Error (Printf.sprintf "Node %s not found in file %s. Available keys: [%s]" 
+                  node_id file_key keys_str)
             | Some node_data ->
                 let children =
                   match U.member "children" node_data with


### PR DESCRIPTION
Fixes #26

## Changes

### 1. figma_get_node_summary - Better error messages
- Now shows available node keys when node not found
- Helps debug node ID format issues

### 2. figma_get_node_bundle - Detailed errors
- Separate error messages for:
  - Missing nodes field
  - Node not found (with available keys)
  - Document is null

### 3. Large result handling - 2KB preview
- Include first 2KB as preview in response
- Add `next_chunk` with ready-to-use figma_read_large_result args
- Users can see data structure without extra tool call