### PR TITLE
fix: finalizer 예외 로깅 추가

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -1,0 +1,33 @@
+let env_true name =
+  match Sys.getenv_opt name with
+  | None -> false
+  | Some v ->
+      let v = String.trim v |> String.lowercase_ascii in
+      v = "1" || v = "true" || v = "yes" || v = "on"
+
+let strict_finalizers () = env_true "FIGMA_MCP_STRICT_FINALIZERS"
+
+let handle_finalizer_error ~module_name ~label ~during_exception ~backtrace ex =
+  let suffix = if during_exception then " (during exception)" else "" in
+  Printf.eprintf "[%s] %s failed in finalizer%s: %s\n%!"
+    module_name label suffix (Printexc.to_string ex);
+  if (not during_exception) && strict_finalizers () then
+    Printexc.raise_with_backtrace ex backtrace
+
+let protect ~module_name ~finally_label ~finally f =
+  match f () with
+  | v ->
+      (try finally () with
+       | ex ->
+           let bt = Printexc.get_raw_backtrace () in
+           handle_finalizer_error ~module_name ~label:finally_label
+             ~during_exception:false ~backtrace:bt ex);
+      v
+  | exception ex ->
+      let bt = Printexc.get_raw_backtrace () in
+      (try finally () with
+       | ex2 ->
+           let bt2 = Printexc.get_raw_backtrace () in
+           handle_finalizer_error ~module_name ~label:finally_label
+             ~during_exception:true ~backtrace:bt2 ex2);
+      Printexc.raise_with_backtrace ex bt

--- a/lib/figma_plugin_bridge.ml
+++ b/lib/figma_plugin_bridge.ml
@@ -36,7 +36,12 @@ let () = Random.self_init ()
 let now () = Unix.gettimeofday ()
 
 let with_lock f =
-  Mutex.protect lock f
+  Mutex.lock lock;
+  Common.protect
+    ~module_name:"figma_plugin_bridge"
+    ~finally_label:"Mutex.unlock"
+    ~finally:(fun () -> Mutex.unlock lock)
+    f
 
 let new_id prefix =
   Printf.sprintf "%s-%d-%d" prefix (int_of_float (now () *. 1000.0)) (Random.bits ())

--- a/lib/mcp_tools.ml
+++ b/lib/mcp_tools.ml
@@ -1177,7 +1177,7 @@ let ( >>| ) result f = match result with
   | Ok v -> Ok (f v)
   | Error e -> Error e
 
-(** 안전한 임시 파일 사용 (try/finally 패턴) *)
+(** 안전한 임시 파일 사용 (Common.protect 패턴) *)
 let with_temp_file ~prefix ~suffix f =
   let path = Printf.sprintf "/tmp/figma-visual/%s_%d_%d%s"
     prefix
@@ -1185,13 +1185,11 @@ let with_temp_file ~prefix ~suffix f =
     (Random.int 100000)
     suffix
   in
-  match f path with
-  | result ->
-      (try Unix.unlink path with _ -> ());
-      result
-  | exception exn ->
-      (try Unix.unlink path with _ -> ());
-      raise exn
+  Common.protect
+    ~module_name:"mcp_tools"
+    ~finally_label:"Unix.unlink"
+    ~finally:(fun () -> Unix.unlink path)
+    (fun () -> f path)
 
 (** 디버그 정보가 포함된 에러 JSON 생성 *)
 let make_error_json ~operation ~error ?(debug_info=[]) () =

--- a/lib/telemetry_jsonl.ml
+++ b/lib/telemetry_jsonl.ml
@@ -34,13 +34,25 @@ let write_mutex = Mutex.create ()
 
 let append_json (json : Yojson.Safe.t) =
   ensure_parent_dir telemetry_file;
-  Mutex.protect write_mutex (fun () ->
-    try
-      Out_channel.with_open_gen [ Open_append; Open_creat; Open_text ] 0o644 telemetry_file (fun oc ->
-        output_string oc (Yojson.Safe.to_string json);
-        output_char oc '\n';
-        flush oc)
-    with _ -> ())
+  Mutex.lock write_mutex;
+  Common.protect
+    ~module_name:"telemetry_jsonl"
+    ~finally_label:"Mutex.unlock"
+    ~finally:(fun () -> Mutex.unlock write_mutex)
+    (fun () ->
+      try
+        let oc =
+          open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 telemetry_file
+        in
+        Common.protect
+          ~module_name:"telemetry_jsonl"
+          ~finally_label:"close_out"
+          ~finally:(fun () -> close_out oc)
+          (fun () ->
+            output_string oc (Yojson.Safe.to_string json);
+            output_char oc '\n';
+            flush oc)
+      with _ -> ())
 
 let log_tool_called ~tool_name ~duration_ms ~success ~error =
   let error_json = match error with Some e -> `String e | None -> `Null in

--- a/lib/visual_verifier.ml
+++ b/lib/visual_verifier.ml
@@ -986,16 +986,18 @@ let ssim_log_path = ".figma-ssim.log"
 let log_verification ~node_id ~ssim ?(notes="") () =
   let timestamp = Unix.gettimeofday () in
   let iso_time =
-    let tm = Unix.localtime timestamp in
+  let tm = Unix.localtime timestamp in
     Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d"
       (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
       tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
   in
   let line = Printf.sprintf "%s|%s|%.4f|%s\n" iso_time node_id ssim notes in
-  (try
-     Out_channel.with_open_gen [Open_append; Open_creat; Open_text] 0o644 ssim_log_path (fun oc ->
-       output_string oc line)
-   with _ -> ())
+  let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 ssim_log_path in
+  Common.protect
+    ~module_name:"visual_verifier"
+    ~finally_label:"close_out"
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc line)
 
 (** SSIM 개선 기록 (before/after 비교)
 

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,11 @@
  (deps
   (glob_files fixtures/*.json)))
 
+; Common finalizer guard tests
+(test
+ (name test_common)
+ (libraries figma_mcp alcotest))
+
 ; MCP Protocol Coverage Tests (JSON-RPC, MCP types, Eio patterns)
 (test
  (name test_mcp_protocol_coverage)

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -1,0 +1,82 @@
+open Alcotest
+
+let set_env name value = Unix.putenv name value
+let unset_env name = Unix.putenv name ""
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  (match value with
+   | Some v -> set_env name v
+   | None -> unset_env name);
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> set_env name v
+      | None -> unset_env name)
+    f
+
+let test_protect_finally_runs () =
+  let called = ref false in
+  let value =
+    Common.protect
+      ~module_name:"test_common"
+      ~finally_label:"finally"
+      ~finally:(fun () -> called := true)
+      (fun () -> 42)
+  in
+  check int "value" 42 value;
+  check bool "finally called" true !called
+
+let test_protect_finally_error_no_raise () =
+  with_env "FIGMA_MCP_STRICT_FINALIZERS" (Some "0") (fun () ->
+    let called = ref false in
+    let value =
+      Common.protect
+        ~module_name:"test_common"
+        ~finally_label:"finally"
+        ~finally:(fun () -> called := true; failwith "boom")
+        (fun () -> 7)
+    in
+    check int "value" 7 value;
+    check bool "finally called" true !called)
+
+let test_protect_finally_error_raise () =
+  with_env "FIGMA_MCP_STRICT_FINALIZERS" (Some "1") (fun () ->
+    let raised =
+      try
+        let _ =
+          Common.protect
+            ~module_name:"test_common"
+            ~finally_label:"finally"
+            ~finally:(fun () -> failwith "boom")
+            (fun () -> 1)
+        in
+        false
+      with Failure _ -> true
+    in
+    check bool "raises in strict mode" true raised)
+
+let test_protect_preserves_exception () =
+  let raised =
+    try
+      let _ =
+        Common.protect
+          ~module_name:"test_common"
+          ~finally_label:"finally"
+          ~finally:(fun () -> failwith "finalizer")
+          (fun () -> failwith "main")
+      in
+      None
+    with Failure msg -> Some msg
+  in
+  check (option string) "main exception preserved" (Some "main") raised
+
+let () =
+  run "Figma_mcp.Common" [
+    "finalizer_guard", [
+      test_case "runs finally" `Quick test_protect_finally_runs;
+      test_case "finalizer error no raise" `Quick test_protect_finally_error_no_raise;
+      test_case "finalizer error raise" `Quick test_protect_finally_error_raise;
+      test_case "preserve main exception" `Quick test_protect_preserves_exception;
+    ];
+  ]


### PR DESCRIPTION
## 변경 사항
- Common.protect 추가: finalizer 예외 로그 + strict 모드 옵션(`FIGMA_MCP_STRICT_FINALIZERS`)
- Fun.protect 사용처를 Common.protect로 교체(뮤텍스/파일 I/O/임시파일/로그)
- Common.protect 테스트 추가

## 테스트
- dune exec --root . test/test_common.exe
