### PR TITLE
fix: accept MCP_API_KEY for HTTP auth

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -9,9 +9,10 @@ let run_mcp_server_stdio () =
   (* Use Eio-based stdio server for pure Eio execution *)
   Figma_mcp.Protocol_eio.start_stdio_server server
 
-let run_mcp_server_http ~port =
+let run_mcp_server_http ~host ~port ~allow_no_auth =
   let server = Figma_mcp.Tools.create_figma_server () in
-  let config = { Figma_mcp.Protocol_eio.default_config with port } in
+  let config = { Figma_mcp.Protocol_eio.default_config with port; host } in
+  Figma_mcp.Protocol_eio.set_allow_no_auth allow_no_auth;
   Figma_mcp.Protocol_eio.start_server ~config server
 
 (** ============== gRPC 서버 모드 ============== *)
@@ -21,7 +22,7 @@ let run_grpc_server ~port =
 
 (** ============== HTTP + gRPC 동시 실행 ============== *)
 
-let run_both_servers ~http_port ~grpc_port =
+let run_both_servers ~host ~http_port ~grpc_port ~allow_no_auth =
   (* Initialize crypto RNG before Eio_main.run - required for TLS/HTTPS *)
   Mirage_crypto_rng_unix.use_default ();
   Eio_main.run @@ fun env ->
@@ -32,7 +33,8 @@ let run_both_servers ~http_port ~grpc_port =
   Eio.Fiber.both
     (fun () ->
       let server = Figma_mcp.Tools.create_figma_server () in
-      let config = { Figma_mcp.Protocol_eio.default_config with port = http_port } in
+      let config = { Figma_mcp.Protocol_eio.default_config with port = http_port; host } in
+      Figma_mcp.Protocol_eio.set_allow_no_auth allow_no_auth;
       Figma_mcp.Protocol_eio.run ~sw ~net ~clock ~domain_mgr config server)
     (fun () ->
       Figma_mcp.Grpc_server.serve ~sw ~env ~port:grpc_port ())
@@ -51,6 +53,15 @@ let server_arg =
   let doc = "Run as MCP stdio server (for Claude Code integration)" in
   Arg.(value & flag & info ["server"] ~doc)
 
+let host_arg =
+  let default_host =
+    match Sys.getenv_opt "FIGMA_MCP_HOST" with
+    | Some v when String.trim v <> "" -> v
+    | _ -> "127.0.0.1"
+  in
+  let doc = "Host to bind (default: 127.0.0.1; non-loopback requires --public or FIGMA_MCP_PUBLIC=1)" in
+  Arg.(value & opt string default_host & info ["host"] ~doc)
+
 let port_arg =
   let doc = "Run as MCP HTTP server on specified port (e.g., --port 8933)" in
   Arg.(value & opt (some int) None & info ["port"] ~doc)
@@ -59,13 +70,64 @@ let grpc_port_arg =
   let doc = "Run as gRPC server on specified port for streaming large responses (default: 50052)" in
   Arg.(value & opt (some int) None & info ["grpc-port"] ~doc)
 
-let run format components server port grpc_port =
+let public_arg =
+  let doc = "Allow binding to non-loopback host (sets FIGMA_MCP_PUBLIC=1)" in
+  Arg.(value & flag & info ["public"] ~doc)
+
+let allow_no_auth_arg =
+  let doc = "Allow running without API key (sets FIGMA_MCP_ALLOW_NO_AUTH=1; not recommended)" in
+  Arg.(value & flag & info ["allow-no-auth"] ~doc)
+
+let normalize_lower s = String.lowercase_ascii s
+let normalize_env value =
+  match value with
+  | None -> None
+  | Some v ->
+      let trimmed = String.trim v in
+      if trimmed = "" then None else Some trimmed
+
+let has_api_key () =
+  match normalize_env (Sys.getenv_opt "FIGMA_MCP_API_KEY") with
+  | Some _ -> true
+  | None ->
+      (match normalize_env (Sys.getenv_opt "MCP_API_KEY") with
+       | Some _ -> true
+       | None -> false)
+
+let is_loopback_host host =
+  match normalize_lower host with
+  | "localhost" | "127.0.0.1" | "::1" | "[::1]" -> true
+  | _ -> false
+
+let require_api_key allow_no_auth =
+  if allow_no_auth then ()
+  else
+    if has_api_key () then ()
+    else begin
+      Printf.eprintf
+        "FIGMA-MCP: FIGMA_MCP_API_KEY (or MCP_API_KEY) is required. Set --allow-no-auth or FIGMA_MCP_ALLOW_NO_AUTH=1 to bypass.\n%!";
+      exit 2
+    end
+
+let run format components server host port grpc_port public allow_no_auth =
+  if public then Unix.putenv "FIGMA_MCP_PUBLIC" "1";
+  if allow_no_auth then Unix.putenv "FIGMA_MCP_ALLOW_NO_AUTH" "1";
+  let public_enabled = Figma_mcp.Mcp_http_auth.env_truthy "FIGMA_MCP_PUBLIC" in
+  let allow_no_auth_enabled = Figma_mcp.Mcp_http_auth.env_truthy "FIGMA_MCP_ALLOW_NO_AUTH" in
+  if (not (is_loopback_host host)) && not public_enabled then begin
+    Printf.eprintf
+      "FIGMA-MCP: Refusing to bind to non-loopback host (%s) without --public or FIGMA_MCP_PUBLIC=1\n%!"
+      host;
+    exit 2
+  end;
+  let http_enabled = match port with Some _ -> true | None -> false in
+  if http_enabled then require_api_key allow_no_auth_enabled;
   match (port, grpc_port) with
   | (Some http_p, Some grpc_p) ->
       (* HTTP + gRPC 동시 실행 *)
-      run_both_servers ~http_port:http_p ~grpc_port:grpc_p
+      run_both_servers ~host ~http_port:http_p ~grpc_port:grpc_p ~allow_no_auth:allow_no_auth_enabled
   | (Some http_p, None) ->
-      run_mcp_server_http ~port:http_p
+      run_mcp_server_http ~host ~port:http_p ~allow_no_auth:allow_no_auth_enabled
   | (None, Some grpc_p) ->
       run_grpc_server ~port:grpc_p
   | (None, None) ->
@@ -113,6 +175,15 @@ let cmd =
     `Pre "  cat figma.json | figma-mcp -f fidelity";
   ] in
   let info = Cmd.info "figma-mcp" ~version:Version.version ~doc ~man in
-  Cmd.v info Term.(const run $ format_arg $ components_arg $ server_arg $ port_arg $ grpc_port_arg)
+  Cmd.v info
+    Term.(const run
+      $ format_arg
+      $ components_arg
+      $ server_arg
+      $ host_arg
+      $ port_arg
+      $ grpc_port_arg
+      $ public_arg
+      $ allow_no_auth_arg)
 
 let () = exit (Cmd.eval cmd)

--- a/lib/mcp_http_auth.ml
+++ b/lib/mcp_http_auth.ml
@@ -1,0 +1,55 @@
+type api_key_error =
+  | Missing
+  | Invalid
+
+let env_truthy name =
+  match Sys.getenv_opt name with
+  | None -> false
+  | Some v ->
+      let lower = String.lowercase_ascii (String.trim v) in
+      lower = "1" || lower = "true" || lower = "yes" || lower = "y" || lower = "on"
+
+let header_value_ci headers name =
+  let target = String.lowercase_ascii name in
+  Httpun.Headers.to_list headers
+  |> List.find_map (fun (k, v) ->
+       if String.lowercase_ascii k = target then Some v else None)
+
+let normalize_key value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let normalize_key_opt value_opt =
+  Option.bind value_opt normalize_key
+
+let extract_bearer value =
+  let prefix = "Bearer " in
+  let prefix_len = String.length prefix in
+  if String.length value > prefix_len &&
+     String.sub value 0 prefix_len = prefix then
+    normalize_key (String.sub value prefix_len (String.length value - prefix_len))
+  else None
+
+let extract_api_key headers =
+  match normalize_key_opt (header_value_ci headers "x-mcp-api-key") with
+  | Some v -> Some v
+  | None ->
+      match normalize_key_opt (header_value_ci headers "x-api-key") with
+      | Some v -> Some v
+      | None ->
+          Option.bind (header_value_ci headers "authorization") extract_bearer
+
+let expected_api_key env_name =
+  match normalize_key_opt (Sys.getenv_opt env_name) with
+  | Some v -> Some v
+  | None -> None
+
+let check_api_key ~env_name ~allow_no_auth headers =
+  if allow_no_auth then Ok ()
+  else
+    match expected_api_key env_name with
+    | None -> Error Missing
+    | Some expected -> (
+        match extract_api_key headers with
+        | Some provided when String.equal provided expected -> Ok ()
+        | _ -> Error Invalid)

--- a/lib/mcp_http_auth.mli
+++ b/lib/mcp_http_auth.mli
@@ -1,0 +1,11 @@
+type api_key_error =
+  | Missing
+  | Invalid
+
+val env_truthy : string -> bool
+val extract_api_key : Httpun.Headers.t -> string option
+val check_api_key :
+  env_name:string ->
+  allow_no_auth:bool ->
+  Httpun.Headers.t ->
+  (unit, api_key_error) result

--- a/lib/mcp_protocol_eio.ml
+++ b/lib/mcp_protocol_eio.ml
@@ -25,6 +25,12 @@ let default_config = {
   max_connections = 64;
 }
 
+let allow_no_auth =
+  ref (Mcp_http_auth.env_truthy "FIGMA_MCP_ALLOW_NO_AUTH"
+       || Mcp_http_auth.env_truthy "MCP_ALLOW_NO_AUTH")
+
+let set_allow_no_auth v = allow_no_auth := v
+
 (** ============== Agent Queue for MCP-style async codegen ============== *)
 
 type agent_status =
@@ -308,32 +314,102 @@ module Cors = struct
 
   let origin_of reqd =
     let request = Httpun.Reqd.request reqd in
-    Httpun.Headers.get request.headers "origin"
+    Httpun.Headers.get request.Httpun.Request.headers "origin"
 
-  let has_prefix ~prefix s =
-    let lp = String.length prefix in
-    String.length s >= lp && String.sub s 0 lp = prefix
+  let normalize_lower s = String.lowercase_ascii s
 
-  let has_suffix ~suffix s =
-    let ls = String.length suffix in
-    let len = String.length s in
-    len >= ls && String.sub s (len - ls) ls = suffix
+  let default_port_for_scheme = function
+    | "http" -> 80
+    | "https" -> 443
+    | _ -> 0
+
+  let parse_origin_components value =
+    try
+      let uri = Uri.of_string value in
+      match (Uri.scheme uri, Uri.host uri) with
+      | (Some scheme, Some host) ->
+          let scheme = normalize_lower scheme in
+          let host = normalize_lower host in
+          let path = Uri.path uri in
+          let query = Uri.query uri in
+          let fragment = Uri.fragment uri in
+          if (path <> "" && path <> "/") || query <> [] || fragment <> None then None
+          else if scheme <> "http" && scheme <> "https" then None
+          else Some (scheme, host, Uri.port uri)
+      | _ -> None
+    with _ -> None
+
+  type origin_value =
+    | Origin_null
+    | Origin of { scheme : string; host : string; port : int option }
+
+  let parse_origin_value value =
+    let value = String.trim value in
+    if value = "null" then Some Origin_null
+    else
+      match parse_origin_components value with
+      | Some (scheme, host, port) -> Some (Origin { scheme; host; port })
+      | None -> None
+
+  type origin_pattern =
+    | Any
+    | Null
+    | Exact of { scheme : string; host : string; port : int option }
+    | Any_port of { scheme : string; host : string }
+
+  let parse_pattern pattern =
+    let pattern = String.trim pattern in
+    if pattern = "*" then Some Any
+    else if pattern = "null" then Some Null
+    else
+      let len = String.length pattern in
+      let ends_with suffix =
+        let ls = String.length suffix in
+        len >= ls && String.sub pattern (len - ls) ls = suffix
+      in
+      if ends_with ":*" then
+        let base = String.sub pattern 0 (len - 2) in
+        match parse_origin_components base with
+        | Some (scheme, host, _) -> Some (Any_port { scheme; host })
+        | None -> None
+      else if ends_with "*" then
+        let base = String.sub pattern 0 (len - 1) in
+        match parse_origin_components base with
+        | Some (scheme, host, _) -> Some (Any_port { scheme; host })
+        | None -> None
+      else
+        match parse_origin_components pattern with
+        | Some (scheme, host, port) -> Some (Exact { scheme; host; port })
+        | None -> None
+
+  let normalized_port scheme port_opt =
+    match port_opt with
+    | Some p -> p
+    | None -> default_port_for_scheme scheme
 
   let matches_pattern origin pattern =
-    let pattern = String.trim pattern in
-    if pattern = "*" then true
-    else if String.length pattern > 0 && pattern.[String.length pattern - 1] = '*'
-    then
-      let prefix = String.sub pattern 0 (String.length pattern - 1) in
-      has_prefix ~prefix origin
-    else if String.length pattern > 0 && pattern.[0] = '*'
-    then
-      let suffix = String.sub pattern 1 (String.length pattern - 1) in
-      has_suffix ~suffix origin
-    else origin = pattern
+    match (origin, pattern) with
+    | (_, Any) -> true
+    | (Origin_null, Null) -> true
+    | (Origin_null, _) -> false
+    | (Origin o, Exact p) ->
+        o.scheme = p.scheme
+        && o.host = p.host
+        && normalized_port o.scheme o.port = normalized_port p.scheme p.port
+    | (Origin o, Any_port p) ->
+        o.scheme = p.scheme && o.host = p.host
+    | _ -> false
 
   let origin_allowed origin =
-    List.exists (matches_pattern origin) allowed_origins
+    match parse_origin_value origin with
+    | None -> false
+    | Some origin_value ->
+        List.exists
+          (fun pattern ->
+            match parse_pattern pattern with
+            | Some parsed -> matches_pattern origin_value parsed
+            | None -> false)
+          allowed_origins
 
   let is_allowed reqd =
     match mode with
@@ -393,6 +469,19 @@ module Response = struct
     let response = Httpun.Response.create ~headers status in
     Httpun.Reqd.respond_with_string reqd response body;
     Server_metrics.finish_reqd ~bytes:(String.length body) reqd status
+
+  let api_key_error message reqd =
+    let body = Yojson.Safe.to_string (`Assoc [
+      ("error", `String message);
+    ]) in
+    let headers = Httpun.Headers.of_list ([
+      ("content-type", "application/json; charset=utf-8");
+      ("content-length", string_of_int (String.length body));
+      ("www-authenticate", "API-Key");
+    ] @ Cors.headers reqd ~include_methods:true ~include_headers:true) in
+    let response = Httpun.Response.create ~headers `Unauthorized in
+    Httpun.Reqd.respond_with_string reqd response body;
+    Server_metrics.finish_reqd ~bytes:(String.length body) reqd `Unauthorized
 
   let accepted reqd =
     let headers = Httpun.Headers.of_list ([
@@ -492,7 +581,7 @@ module Request = struct
   let read_body_async reqd callback =
     let request = Httpun.Reqd.request reqd in
     let content_length =
-      match Httpun.Headers.get request.headers "content-length" with
+      match Httpun.Headers.get request.Httpun.Request.headers "content-length" with
       | Some v -> parse_positive_int v
       | None -> None
     in
@@ -546,7 +635,7 @@ module Request = struct
 
   (** Check if client accepts SSE (MCP Streamable HTTP) *)
   let accepts_sse (request : Httpun.Request.t) =
-    match Httpun.Headers.get request.headers "accept" with
+    match Httpun.Headers.get request.Httpun.Request.headers "accept" with
     | Some accept ->
         let accept_lower = String.lowercase_ascii accept in
         (try
@@ -3080,121 +3169,161 @@ body { font-family: 'Inter', -apple-system, sans-serif; }
 
 (** ============== Router ============== *)
 
+let is_public_path meth path =
+  match (meth, path) with
+  | (`OPTIONS, _) -> true
+  | (`GET, "/health") -> true
+  | _ -> false
+
+let normalize_env value =
+  match value with
+  | None -> None
+  | Some v ->
+      let trimmed = String.trim v in
+      if trimmed = "" then None else Some trimmed
+
+let api_key_env_name () =
+  match normalize_env (Sys.getenv_opt "FIGMA_MCP_API_KEY") with
+  | Some _ -> "FIGMA_MCP_API_KEY"
+  | None ->
+      (match normalize_env (Sys.getenv_opt "MCP_API_KEY") with
+       | Some _ -> "MCP_API_KEY"
+       | None -> "FIGMA_MCP_API_KEY")
+
+let check_api_key request =
+  let env_name = api_key_env_name () in
+  match Mcp_http_auth.check_api_key
+          ~env_name
+          ~allow_no_auth:!allow_no_auth
+          request.Httpun.Request.headers with
+  | Ok () -> Ok ()
+  | Error Mcp_http_auth.Missing -> Error "API key required"
+  | Error Mcp_http_auth.Invalid -> Error "Invalid API key"
+
 let route_request ~clock ~domain_mgr ~sw ~eio_ctx server request reqd =
   let path = Request.path request in
   let meth = Request.method_ request in
+  let public_path = is_public_path meth path in
 
   if not (Cors.is_allowed reqd) then
     Response.text ~status:`Forbidden "Forbidden" reqd
   else
-    match (meth, path) with
-  | `OPTIONS, _ ->
-      Response.cors_preflight reqd
+    let route () =
+      match (meth, path) with
+      | `OPTIONS, _ ->
+          Response.cors_preflight reqd
 
-  | `GET, "/health" ->
-      health_handler request reqd
+      | `GET, "/health" ->
+          health_handler request reqd
 
-  | `GET, "/metrics" ->
-      Response.text (Server_metrics.to_prometheus_text ()) reqd
+      | `GET, "/metrics" ->
+          Response.text (Server_metrics.to_prometheus_text ()) reqd
 
-  | `GET, "/stats" ->
-      let result = `Assoc [
-        ("server_metrics", Server_metrics.to_json ());
-        ("agent_queue", agent_queue_stats_json ());
-      ] in
-      Response.json (Yojson.Safe.to_string result) reqd
+      | `GET, "/stats" ->
+          let result = `Assoc [
+            ("server_metrics", Server_metrics.to_json ());
+            ("agent_queue", agent_queue_stats_json ());
+          ] in
+          Response.json (Yojson.Safe.to_string result) reqd
 
-  | `GET, "/" ->
-      Response.text (sprintf "🎨 %s MCP Server (Eio)" Mcp_protocol.server_name) reqd
+      | `GET, "/" ->
+          Response.text (sprintf "🎨 %s MCP Server (Eio)" Mcp_protocol.server_name) reqd
 
-  | `GET, "/mcp" ->
-      (* SSE stream for MCP streamable-http protocol *)
-      mcp_sse_handler ~clock request reqd
+      | `GET, "/mcp" ->
+          (* SSE stream for MCP streamable-http protocol *)
+          mcp_sse_handler ~clock request reqd
 
-  | `GET, "/plugin/status" ->
-      plugin_status_handler request reqd
+      | `GET, "/plugin/status" ->
+          plugin_status_handler request reqd
 
-  | `POST, "/" | `POST, "/mcp" ->
-      mcp_post_handler ~sw ~domain_mgr ~eio_ctx server request reqd
+      | `POST, "/" | `POST, "/mcp" ->
+          mcp_post_handler ~sw ~domain_mgr ~eio_ctx server request reqd
 
-  | `POST, "/plugin/connect" ->
-      plugin_connect_handler request reqd
+      | `POST, "/plugin/connect" ->
+          plugin_connect_handler request reqd
 
-  | `POST, "/plugin/poll" ->
-      plugin_poll_handler ~clock request reqd
+      | `POST, "/plugin/poll" ->
+          plugin_poll_handler ~clock request reqd
 
-  | `POST, "/plugin/result" ->
-      plugin_result_handler request reqd
+      | `POST, "/plugin/result" ->
+          plugin_result_handler request reqd
 
-  | `POST, "/plugin/codegen" ->
-      plugin_codegen_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/codegen" ->
+          plugin_codegen_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/template" ->
-      template_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/template" ->
+          template_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/code-to-figma" ->
-      code_to_figma_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/code-to-figma" ->
+          code_to_figma_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/vision-compare" ->
-      vision_compare_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/vision-compare" ->
+          vision_compare_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/analyze" ->
-      plugin_analyze_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/analyze" ->
+          plugin_analyze_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/extract-tokens" ->
-      extract_tokens_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/extract-tokens" ->
+          extract_tokens_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/generate-story" ->
-      generate_story_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/generate-story" ->
+          generate_story_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/codegen-multi" ->
-      codegen_multi_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/codegen-multi" ->
+          codegen_multi_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/extract-variants" ->
-      extract_variants_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/extract-variants" ->
+          extract_variants_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/responsive-breakpoints" ->
-      responsive_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/responsive-breakpoints" ->
+          responsive_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/accessibility" ->
-      accessibility_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/accessibility" ->
+          accessibility_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/export-assets" ->
-      export_assets_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/export-assets" ->
+          export_assets_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/plugin/extract-animations" ->
-      extract_animations_handler ~sw ~eio_ctx request reqd
+      | `POST, "/plugin/extract-animations" ->
+          extract_animations_handler ~sw ~eio_ctx request reqd
 
-  | `POST, "/webhook/figma" ->
-      webhook_handler ~sw ~eio_ctx request reqd
+      | `POST, "/webhook/figma" ->
+          webhook_handler ~sw ~eio_ctx request reqd
 
-  (* Agent Queue endpoints *)
-  | `POST, "/agent/request" ->
-      agent_request_handler request reqd
+      (* Agent Queue endpoints *)
+      | `POST, "/agent/request" ->
+          agent_request_handler request reqd
 
-  | `POST, "/agent/claim" ->
-      agent_claim_handler request reqd
+      | `POST, "/agent/claim" ->
+          agent_claim_handler request reqd
 
-  | `POST, "/agent/heartbeat" ->
-      agent_heartbeat_handler request reqd
+      | `POST, "/agent/heartbeat" ->
+          agent_heartbeat_handler request reqd
 
-  | `POST, "/agent/abandon" ->
-      agent_abandon_handler request reqd
+      | `POST, "/agent/abandon" ->
+          agent_abandon_handler request reqd
 
-  | `GET, "/agent/pending" ->
-      agent_pending_handler request reqd
+      | `GET, "/agent/pending" ->
+          agent_pending_handler request reqd
 
-  | `POST, "/agent/result" ->
-      agent_result_handler request reqd
+      | `POST, "/agent/result" ->
+          agent_result_handler request reqd
 
-  | `GET, path when String.length path > 14 && String.sub path 0 14 = "/agent/status/" ->
-      agent_status_handler request reqd
+      | `GET, path when String.length path > 14 && String.sub path 0 14 = "/agent/status/" ->
+          agent_status_handler request reqd
 
-  | `GET, "/agent/queue" ->
-      agent_queue_handler request reqd
+      | `GET, "/agent/queue" ->
+          agent_queue_handler request reqd
 
-  | _ ->
-      Response.not_found reqd
+      | _ ->
+          Response.not_found reqd
+    in
+    if public_path then
+      route ()
+    else
+      match check_api_key request with
+      | Ok () -> route ()
+      | Error msg -> Response.api_key_error msg reqd
 
 (** ============== httpun-eio Server ============== *)
 

--- a/start-figma-mcp-http.sh
+++ b/start-figma-mcp-http.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Figma MCP Server (HTTP) - Start Script
-# Usage: ./start-figma-mcp-http.sh [--port PORT] [--grpc-port PORT]
+# Usage: ./start-figma-mcp-http.sh [--port PORT] [--grpc-port PORT] [--host HOST] [--public] [--allow-no-auth]
 
 set -e
 
@@ -47,6 +47,9 @@ cd "$SCRIPT_DIR"
 
 PORT="${FIGMA_MCP_PORT:-8940}"
 GRPC_PORT="${FIGMA_MCP_GRPC_PORT:-}"
+HOST="${FIGMA_MCP_HOST:-127.0.0.1}"
+PUBLIC="${FIGMA_MCP_PUBLIC:-}"
+ALLOW_NO_AUTH="${FIGMA_MCP_ALLOW_NO_AUTH:-}"
 
 EXPECTED_VERSION=""
 if [ -f "$SCRIPT_DIR/dune-project" ]; then
@@ -61,11 +64,26 @@ get_binary_version() {
 }
 
 # Parse arguments
+is_truthy() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --port)
       PORT="$2"
       shift 2
+      ;;
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --host=*)
+      HOST="${1#*=}"
+      shift 1
       ;;
     --grpc-port)
       GRPC_PORT="$2"
@@ -75,10 +93,21 @@ while [[ $# -gt 0 ]]; do
       GRPC_PORT="${1#*=}"
       shift 1
       ;;
+    --public)
+      PUBLIC="1"
+      shift 1
+      ;;
+    --allow-no-auth)
+      ALLOW_NO_AUTH="1"
+      shift 1
+      ;;
     -h|--help)
-      echo "Usage: $0 [--port PORT] [--grpc-port PORT]"
+      echo "Usage: $0 [--port PORT] [--grpc-port PORT] [--host HOST] [--public] [--allow-no-auth]"
       echo "  --port PORT  Server port (default: 8940)"
       echo "  --grpc-port PORT  gRPC port (optional, enables streaming)"
+      echo "  --host HOST  Host to bind (default: 127.0.0.1)"
+      echo "  --public  Allow non-loopback host (sets FIGMA_MCP_PUBLIC=1)"
+      echo "  --allow-no-auth  Allow running without API key (not recommended)"
       exit 0
       ;;
     *)
@@ -87,6 +116,13 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if ! is_truthy "$ALLOW_NO_AUTH"; then
+  if [ -z "${FIGMA_MCP_API_KEY:-}" ] && [ -z "${MCP_API_KEY:-}" ]; then
+    echo "Error: FIGMA_MCP_API_KEY (or MCP_API_KEY) is required. Set --allow-no-auth or FIGMA_MCP_ALLOW_NO_AUTH=1 to bypass." >&2
+    exit 2
+  fi
+fi
 
 # Resolve executable path (prefer workspace build dir)
 WORKSPACE_EXE="$SCRIPT_DIR/../_build/default/figma-mcp/bin/main.exe"
@@ -137,10 +173,16 @@ if [ -z "$FIGMA_EXE" ]; then
   fi
 fi
 
+ARGS=(--port "$PORT" --host "$HOST")
 if [ -n "$GRPC_PORT" ]; then
-  echo "Using figma-mcp binary: $FIGMA_EXE" >&2
-  exec "$FIGMA_EXE" --port "$PORT" --grpc-port "$GRPC_PORT"
-else
-  echo "Using figma-mcp binary: $FIGMA_EXE" >&2
-  exec "$FIGMA_EXE" --port "$PORT"
+  ARGS+=(--grpc-port "$GRPC_PORT")
 fi
+if is_truthy "$PUBLIC"; then
+  ARGS+=(--public)
+fi
+if is_truthy "$ALLOW_NO_AUTH"; then
+  ARGS+=(--allow-no-auth)
+fi
+
+echo "Using figma-mcp binary: $FIGMA_EXE" >&2
+exec "$FIGMA_EXE" "${ARGS[@]}"

--- a/start-figma-mcp.sh
+++ b/start-figma-mcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Figma MCP Server (HTTP) - Start Script
-# Usage: ./start-figma-mcp-http.sh [--port PORT] [--grpc-port PORT]
+# Usage: ./start-figma-mcp.sh [--port PORT] [--grpc-port PORT] [--host HOST] [--public] [--allow-no-auth]
 
 set -e
 
@@ -47,6 +47,9 @@ cd "$SCRIPT_DIR"
 
 PORT="${FIGMA_MCP_PORT:-8940}"
 GRPC_PORT="${FIGMA_MCP_GRPC_PORT:-}"
+HOST="${FIGMA_MCP_HOST:-127.0.0.1}"
+PUBLIC="${FIGMA_MCP_PUBLIC:-}"
+ALLOW_NO_AUTH="${FIGMA_MCP_ALLOW_NO_AUTH:-}"
 
 EXPECTED_VERSION=""
 if [ -f "$SCRIPT_DIR/dune-project" ]; then
@@ -61,11 +64,26 @@ get_binary_version() {
 }
 
 # Parse arguments
+is_truthy() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --port)
       PORT="$2"
       shift 2
+      ;;
+    --host)
+      HOST="$2"
+      shift 2
+      ;;
+    --host=*)
+      HOST="${1#*=}"
+      shift 1
       ;;
     --grpc-port)
       GRPC_PORT="$2"
@@ -75,10 +93,21 @@ while [[ $# -gt 0 ]]; do
       GRPC_PORT="${1#*=}"
       shift 1
       ;;
+    --public)
+      PUBLIC="1"
+      shift 1
+      ;;
+    --allow-no-auth)
+      ALLOW_NO_AUTH="1"
+      shift 1
+      ;;
     -h|--help)
-      echo "Usage: $0 [--port PORT] [--grpc-port PORT]"
+      echo "Usage: $0 [--port PORT] [--grpc-port PORT] [--host HOST] [--public] [--allow-no-auth]"
       echo "  --port PORT  Server port (default: 8940)"
       echo "  --grpc-port PORT  gRPC port (optional, enables streaming)"
+      echo "  --host HOST  Host to bind (default: 127.0.0.1)"
+      echo "  --public  Allow non-loopback host (sets FIGMA_MCP_PUBLIC=1)"
+      echo "  --allow-no-auth  Allow running without API key (not recommended)"
       exit 0
       ;;
     *)
@@ -87,6 +116,13 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if ! is_truthy "$ALLOW_NO_AUTH"; then
+  if [ -z "${FIGMA_MCP_API_KEY:-}" ] && [ -z "${MCP_API_KEY:-}" ]; then
+    echo "Error: FIGMA_MCP_API_KEY (or MCP_API_KEY) is required. Set --allow-no-auth or FIGMA_MCP_ALLOW_NO_AUTH=1 to bypass." >&2
+    exit 2
+  fi
+fi
 
 # Resolve executable path (prefer workspace build dir)
 WORKSPACE_EXE="$SCRIPT_DIR/../_build/default/figma-mcp/bin/main.exe"
@@ -137,10 +173,16 @@ if [ -z "$FIGMA_EXE" ]; then
   fi
 fi
 
+ARGS=(--port "$PORT" --host "$HOST")
 if [ -n "$GRPC_PORT" ]; then
-  echo "Using figma-mcp binary: $FIGMA_EXE" >&2
-  exec "$FIGMA_EXE" --port "$PORT" --grpc-port "$GRPC_PORT"
-else
-  echo "Using figma-mcp binary: $FIGMA_EXE" >&2
-  exec "$FIGMA_EXE" --port "$PORT"
+  ARGS+=(--grpc-port "$GRPC_PORT")
 fi
+if is_truthy "$PUBLIC"; then
+  ARGS+=(--public)
+fi
+if is_truthy "$ALLOW_NO_AUTH"; then
+  ARGS+=(--allow-no-auth)
+fi
+
+echo "Using figma-mcp binary: $FIGMA_EXE" >&2
+exec "$FIGMA_EXE" "${ARGS[@]}"

--- a/test/dune
+++ b/test/dune
@@ -102,3 +102,8 @@
 (test
  (name test_plugin_features)
  (libraries figma_mcp alcotest yojson str))
+
+; MCP HTTP API key auth tests
+(test
+ (name test_mcp_http_auth)
+ (libraries figma_mcp alcotest httpun unix))

--- a/test/test_mcp_http_auth.ml
+++ b/test/test_mcp_http_auth.ml
@@ -1,0 +1,98 @@
+open Alcotest
+
+let headers_of_list = Httpun.Headers.of_list
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  let restore () =
+    match prev with
+    | None -> Unix.putenv name ""
+    | Some v -> Unix.putenv name v
+  in
+  (match value with
+  | None -> Unix.putenv name ""
+  | Some v -> Unix.putenv name v);
+  match f () with
+  | result ->
+      restore ();
+      result
+  | exception exn ->
+      restore ();
+      raise exn
+
+let test_extract_x_mcp_api_key () =
+  let headers = headers_of_list [ ("X-MCP-API-Key", "abc123") ] in
+  check (option string) "x-mcp-api-key" (Some "abc123")
+    (Figma_mcp.Mcp_http_auth.extract_api_key headers)
+
+let test_extract_x_api_key_fallback () =
+  let headers = headers_of_list [ ("X-API-Key", "fallback") ] in
+  check (option string) "x-api-key" (Some "fallback")
+    (Figma_mcp.Mcp_http_auth.extract_api_key headers)
+
+let test_extract_bearer_token () =
+  let headers = headers_of_list [ ("Authorization", "Bearer token123") ] in
+  check (option string) "authorization bearer" (Some "token123")
+    (Figma_mcp.Mcp_http_auth.extract_api_key headers)
+
+let test_check_api_key_missing () =
+  let headers = headers_of_list [] in
+  with_env "FIGMA_MCP_API_KEY" None (fun () ->
+      match
+        Figma_mcp.Mcp_http_auth.check_api_key ~env_name:"FIGMA_MCP_API_KEY"
+          ~allow_no_auth:false headers
+      with
+      | Error Figma_mcp.Mcp_http_auth.Missing -> ()
+      | _ -> fail "expected Missing")
+
+let test_check_api_key_invalid () =
+  let headers = headers_of_list [ ("X-MCP-API-Key", "nope") ] in
+  with_env "FIGMA_MCP_API_KEY" (Some "secret") (fun () ->
+      match
+        Figma_mcp.Mcp_http_auth.check_api_key ~env_name:"FIGMA_MCP_API_KEY"
+          ~allow_no_auth:false headers
+      with
+      | Error Figma_mcp.Mcp_http_auth.Invalid -> ()
+      | _ -> fail "expected Invalid")
+
+let test_check_api_key_ok () =
+  let headers = headers_of_list [ ("X-MCP-API-Key", "secret") ] in
+  with_env "FIGMA_MCP_API_KEY" (Some "secret") (fun () ->
+      match
+        Figma_mcp.Mcp_http_auth.check_api_key ~env_name:"FIGMA_MCP_API_KEY"
+          ~allow_no_auth:false headers
+      with
+      | Ok () -> ()
+      | _ -> fail "expected Ok")
+
+let test_check_mcp_api_key_ok () =
+  let headers = headers_of_list [ ("X-MCP-API-Key", "secret") ] in
+  with_env "MCP_API_KEY" (Some "secret") (fun () ->
+      match
+        Figma_mcp.Mcp_http_auth.check_api_key ~env_name:"MCP_API_KEY"
+          ~allow_no_auth:false headers
+      with
+      | Ok () -> ()
+      | _ -> fail "expected Ok")
+
+let test_allow_no_auth () =
+  let headers = headers_of_list [] in
+  with_env "FIGMA_MCP_API_KEY" None (fun () ->
+      match
+        Figma_mcp.Mcp_http_auth.check_api_key ~env_name:"FIGMA_MCP_API_KEY"
+          ~allow_no_auth:true headers
+      with
+      | Ok () -> ()
+      | _ -> fail "expected Ok")
+
+let () =
+  run "mcp_http_auth"
+    [ ( "mcp_http_auth",
+        [ test_case "extract x-mcp-api-key" `Quick test_extract_x_mcp_api_key;
+          test_case "extract x-api-key" `Quick test_extract_x_api_key_fallback;
+          test_case "extract bearer" `Quick test_extract_bearer_token;
+          test_case "check missing" `Quick test_check_api_key_missing;
+          test_case "check invalid" `Quick test_check_api_key_invalid;
+          test_case "check ok" `Quick test_check_api_key_ok;
+          test_case "check MCP_API_KEY ok" `Quick test_check_mcp_api_key_ok;
+          test_case "allow no auth" `Quick test_allow_no_auth ] ) ]


### PR DESCRIPTION
## Summary
- accept MCP_API_KEY as fallback for HTTP auth
- preflight in start scripts allows FIGMA_MCP_API_KEY or MCP_API_KEY
- add mcp_http_auth helper + tests

## Testing
- dune test --root .