### PR TITLE
feat(cors): add strict/compat CORS profile defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ security add-generic-password -s "figma-mcp" -a "FIGMA_TOKEN" -w "YOUR_TOKEN"
 
 ## CORS 설정 (HTTP)
 
+- `FIGMA_MCP_CORS_PROFILE`: `compat`(기본) 또는 `strict` (기본값 프리셋; `strict` 기본값은 `null` 불허 + `access-control-allow-private-network` 비활성화)
 - `FIGMA_MCP_CORS_MODE`: `restrict`(기본) 또는 `permissive`
-- `FIGMA_MCP_CORS_ALLOWED_ORIGINS`: 허용 Origin 목록 (쉼표 구분, 예: `https://app.example.com,https://*.example.com`)
+- `FIGMA_MCP_CORS_ALLOWED_ORIGINS`: 허용 Origin 목록 (쉼표 구분, 예: `https://app.example.com,http://localhost:*`). 지원: `null`, `*`, `:*`(port wildcard)
 - `FIGMA_MCP_CORS_ALLOW_PRIVATE_NETWORK`: `true`일 때 `access-control-allow-private-network` 헤더 추가
 - `FIGMA_MCP_CORS_ALLOW_HEADERS`: 허용 헤더 목록 (기본: `Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Authorization, X-API-Key, X-MCP-API-Key, Access-Control-Request-Private-Network`)
 

--- a/lib/figma_config.ml
+++ b/lib/figma_config.ml
@@ -156,25 +156,54 @@ end
 (** {1 CORS Configuration} *)
 
 module Cors = struct
+  type profile =
+    | Compat
+    | Strict
+
+  let get_string_nonempty ~default name =
+    match Sys.getenv_opt name with
+    | Some v when String.trim v <> "" -> v
+    | _ -> default
+
+  let profile () =
+    match get_string_nonempty ~default:"compat" "FIGMA_MCP_CORS_PROFILE" |> String.lowercase_ascii with
+    | "strict" -> Strict
+    | _ -> Compat
+
+  let allowed_origins_default () =
+    match profile () with
+    | Compat -> ["http://localhost:*"; "http://127.0.0.1:*"; "https://www.figma.com"; "null"]
+    | Strict -> ["https://www.figma.com"]
+
+  let allow_private_network_default () =
+    match profile () with
+    | Compat -> true
+    | Strict -> false
+
+  let allow_headers_default () =
+    match profile () with
+    | Compat ->
+        "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Authorization, X-API-Key, X-MCP-API-Key, Access-Control-Request-Private-Network"
+    | Strict ->
+        "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Authorization, X-API-Key, X-MCP-API-Key"
+
   (** restrict | permissive *)
-  let mode =
-    get_string ~default:"restrict" "FIGMA_MCP_CORS_MODE"
+  let mode () =
+    get_string_nonempty ~default:"restrict" "FIGMA_MCP_CORS_MODE"
 
   (** Allowed origins, supports :* port wildcard (e.g., http://localhost:* ) *)
-  let allowed_origins =
+  let allowed_origins () =
     get_string_list
-      ~default:["http://localhost:*"; "http://127.0.0.1:*"; "https://www.figma.com"; "null"]
+      ~default:(allowed_origins_default ())
       "FIGMA_MCP_CORS_ALLOWED_ORIGINS"
 
   (** Allow private network access from browser preflight *)
-  let allow_private_network =
-    get_bool ~default:true "FIGMA_MCP_CORS_ALLOW_PRIVATE_NETWORK"
+  let allow_private_network () =
+    get_bool ~default:(allow_private_network_default ()) "FIGMA_MCP_CORS_ALLOW_PRIVATE_NETWORK"
 
   (** Allow headers list for preflight *)
-  let allow_headers =
-    get_string
-      ~default:"Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Authorization, X-API-Key, X-MCP-API-Key, Access-Control-Request-Private-Network"
-      "FIGMA_MCP_CORS_ALLOW_HEADERS"
+  let allow_headers () =
+    get_string_nonempty ~default:(allow_headers_default ()) "FIGMA_MCP_CORS_ALLOW_HEADERS"
 end
 
 (** {1 Asset Configuration} *)

--- a/lib/mcp_protocol_eio.ml
+++ b/lib/mcp_protocol_eio.ml
@@ -307,10 +307,10 @@ let agent_queue_stats_json () =
 (** ============== Request/Response Helpers ============== *)
 
 module Cors = struct
-  let mode = String.lowercase_ascii Figma_config.Cors.mode
-  let allowed_origins = Figma_config.Cors.allowed_origins
-  let allow_private_network = Figma_config.Cors.allow_private_network
-  let allow_headers = Figma_config.Cors.allow_headers
+  let mode () = String.lowercase_ascii (Figma_config.Cors.mode ())
+  let allowed_origins () = Figma_config.Cors.allowed_origins ()
+  let allow_private_network () = Figma_config.Cors.allow_private_network ()
+  let allow_headers () = Figma_config.Cors.allow_headers ()
 
   let origin_of reqd =
     let request = Httpun.Reqd.request reqd in
@@ -404,51 +404,55 @@ module Cors = struct
     match parse_origin_value origin with
     | None -> false
     | Some origin_value ->
+        let allowed = allowed_origins () in
         List.exists
           (fun pattern ->
             match parse_pattern pattern with
             | Some parsed -> matches_pattern origin_value parsed
             | None -> false)
-          allowed_origins
+          allowed
 
   let is_allowed reqd =
-    match mode with
+    match mode () with
     | "restrict" -> (
         match origin_of reqd with
         | None -> true
         | Some origin -> origin_allowed origin)
     | _ -> true
 
-  let allow_origin_value reqd =
-    match mode with
+  let allow_origin_value_of_origin_opt origin_opt =
+    match mode () with
     | "permissive" -> Some "*"
     | "restrict" -> (
-        match origin_of reqd with
+        match origin_opt with
         | Some origin when origin_allowed origin -> Some origin
         | _ -> None)
     | _ -> Some "*"
 
-  let headers reqd ~include_methods ~include_headers =
-    let base =
-      match allow_origin_value reqd with
-      | Some origin ->
+  let headers_for_origin_opt origin_opt ~include_methods ~include_headers =
+    match allow_origin_value_of_origin_opt origin_opt with
+    | None -> []
+    | Some origin ->
+        let base =
           let vary = if origin = "*" then [] else [("vary", "Origin")] in
           ("access-control-allow-origin", origin) :: vary
-      | None -> []
-    in
-    let headers =
-      if include_methods then
-        ("access-control-allow-methods", "GET, POST, OPTIONS") :: base
-      else base
-    in
-    let headers =
-      if include_headers then
-        ("access-control-allow-headers", allow_headers) :: headers
-      else headers
-    in
-    if allow_private_network then
-      ("access-control-allow-private-network", "true") :: headers
-    else headers
+        in
+        let headers =
+          if include_methods then
+            ("access-control-allow-methods", "GET, POST, OPTIONS") :: base
+          else base
+        in
+        let headers =
+          if include_headers then
+            ("access-control-allow-headers", allow_headers ()) :: headers
+          else headers
+        in
+        if allow_private_network () then
+          ("access-control-allow-private-network", "true") :: headers
+        else headers
+
+  let headers reqd ~include_methods ~include_headers =
+    headers_for_origin_opt (origin_of reqd) ~include_methods ~include_headers
 end
 
 module Response = struct

--- a/test/dune
+++ b/test/dune
@@ -108,6 +108,11 @@
  (name test_mcp_http_auth)
  (libraries figma_mcp alcotest httpun unix))
 
+; CORS profile defaults (compat vs strict)
+(test
+ (name test_cors_profile)
+ (libraries figma_mcp alcotest))
+
 ; Coverage: figma_compare.ml (227 points, all branches)
 (test
  (name test_figma_compare)

--- a/test/test_cors_profile.ml
+++ b/test/test_cors_profile.ml
@@ -1,0 +1,104 @@
+open Alcotest
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let with_envs pairs f =
+  let rec loop pairs f =
+    match pairs with
+    | [] -> f ()
+    | (k, v) :: rest -> with_env k v (fun () -> loop rest f)
+  in
+  loop pairs f
+
+let has_header name headers =
+  let name = String.lowercase_ascii name in
+  List.exists (fun (k, _) -> String.lowercase_ascii k = name) headers
+
+let find_header name headers =
+  let name = String.lowercase_ascii name in
+  List.find_opt (fun (k, _) -> String.lowercase_ascii k = name) headers
+
+let test_strict_denies_null_by_default () =
+  with_envs
+    [ ("FIGMA_MCP_CORS_PROFILE", Some "strict");
+      ("FIGMA_MCP_CORS_ALLOWED_ORIGINS", None);
+      ("FIGMA_MCP_CORS_MODE", None) ]
+    (fun () ->
+      check bool "origin_allowed null" false (Mcp_protocol_eio.Cors.origin_allowed "null");
+      let headers =
+        Mcp_protocol_eio.Cors.headers_for_origin_opt (Some "null")
+          ~include_methods:false ~include_headers:false
+      in
+      check bool "no allow-origin header" false
+        (has_header "access-control-allow-origin" headers))
+
+let test_strict_disables_private_network_by_default () =
+  with_envs
+    [ ("FIGMA_MCP_CORS_PROFILE", Some "strict");
+      ("FIGMA_MCP_CORS_ALLOWED_ORIGINS", None);
+      ("FIGMA_MCP_CORS_ALLOW_PRIVATE_NETWORK", None);
+      ("FIGMA_MCP_CORS_MODE", None) ]
+    (fun () ->
+      check bool "origin_allowed figma" true
+        (Mcp_protocol_eio.Cors.origin_allowed "https://www.figma.com");
+      let headers =
+        Mcp_protocol_eio.Cors.headers_for_origin_opt (Some "https://www.figma.com")
+          ~include_methods:false ~include_headers:false
+      in
+      check bool "no private network header" false
+        (has_header "access-control-allow-private-network" headers))
+
+let test_compat_allows_null_and_private_network_by_default () =
+  with_envs
+    [ ("FIGMA_MCP_CORS_PROFILE", Some "compat");
+      ("FIGMA_MCP_CORS_ALLOWED_ORIGINS", None);
+      ("FIGMA_MCP_CORS_ALLOW_PRIVATE_NETWORK", None);
+      ("FIGMA_MCP_CORS_MODE", None) ]
+    (fun () ->
+      check bool "origin_allowed null" true (Mcp_protocol_eio.Cors.origin_allowed "null");
+      let headers =
+        Mcp_protocol_eio.Cors.headers_for_origin_opt (Some "null")
+          ~include_methods:false ~include_headers:false
+      in
+      (match find_header "access-control-allow-origin" headers with
+       | Some (_, v) -> check string "allow-origin value" "null" v
+       | None -> fail "expected access-control-allow-origin");
+      check bool "private network header present" true
+        (has_header "access-control-allow-private-network" headers))
+
+let test_strict_override_allowed_origins_and_private_network () =
+  with_envs
+    [ ("FIGMA_MCP_CORS_PROFILE", Some "strict");
+      ("FIGMA_MCP_CORS_ALLOWED_ORIGINS", Some "null, https://www.figma.com");
+      ("FIGMA_MCP_CORS_ALLOW_PRIVATE_NETWORK", Some "true");
+      ("FIGMA_MCP_CORS_MODE", None) ]
+    (fun () ->
+      check bool "origin_allowed null" true (Mcp_protocol_eio.Cors.origin_allowed "null");
+      let headers =
+        Mcp_protocol_eio.Cors.headers_for_origin_opt (Some "null")
+          ~include_methods:false ~include_headers:false
+      in
+      check bool "private network header present" true
+        (has_header "access-control-allow-private-network" headers))
+
+let () =
+  run "cors_profile"
+    [ ( "cors_profile",
+        [ test_case "strict denies null by default" `Quick test_strict_denies_null_by_default;
+          test_case "strict disables private network by default" `Quick
+            test_strict_disables_private_network_by_default;
+          test_case "compat allows null + private network by default" `Quick
+            test_compat_allows_null_and_private_network_by_default;
+          test_case "strict override envs" `Quick
+            test_strict_override_allowed_origins_and_private_network ] ) ]
+


### PR DESCRIPTION
## What
- Add `FIGMA_MCP_CORS_PROFILE` preset: `compat` (default) vs `strict`.
- Make CORS config read dynamically (so tests can validate profiles) and only emit CORS headers when an origin is actually allowed.

## Why
- Default behavior stays compatible for Figma plugin/webview flows (`null` + localhost + private-network header).
- `strict` gives a safer out-of-the-box posture for deployments that want to avoid `Origin: null` and Private Network Access by default.

## Notes
- `FIGMA_MCP_CORS_*` env vars still override the preset defaults.
- New tests: `test/test_cors_profile.ml`.

## Test
- `dune test --root . -f`
