### PR TITLE
fix(search): add depth limit to file fetch in handle_search

### DIFF
--- a/lib/mcp_tools.ml
+++ b/lib/mcp_tools.ml
@@ -6908,7 +6908,8 @@ let handle_search args : (Yojson.Safe.t, string) result =
 
   match (file_key, token, query) with
   | (Some file_key, Some token, Some query) ->
-      (match Figma_effects.Perform.get_file ~token ~file_key () with
+      (* depth:4 covers Page→Frame→Group→Component; avoids 400 on large files *)
+      (match Figma_effects.Perform.get_file ~token ~file_key ~depth:4 () with
        | Ok json ->
            (match Figma_api.extract_document json with
             | Some doc_json ->


### PR DESCRIPTION
## Problem
`handle_search` calls `get_file` without `depth` parameter, downloading the entire Figma document tree. For large files (e.g. 혜택 및 리워드), this causes:
- HTTP 400 from Figma API (payload too large or malformed)
- Cloud Run 504 gateway timeout (response exceeds timeout window)

## Fix
Add `~depth:4` to the `get_file` call. Depth 4 covers Page → Frame → Group → Component, which captures most searchable nodes while keeping payloads manageable.

## Testing
- `GET /v1/files/{key}?depth=1` returns 200 for the same file that fails without depth
- Search results include components and frames up to 4 levels deep
