### PR TITLE
fix: disable Domain_manager.run for MCP requests

### DIFF
--- a/lib/mcp_protocol_eio.ml
+++ b/lib/mcp_protocol_eio.ml
@@ -3495,7 +3495,13 @@ let start_server ?(config = default_config) server =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let domain_mgr = Some (Eio.Stdenv.domain_mgr env) in
+  (* Domain_manager.run dispatches MCP requests to separate OS domains.
+     Eio capabilities (net, clock, client) are tied to the main domain's
+     event loop; using them from spawned domains causes
+     "Switch accessed from wrong domain!" errors.
+     Eio fibers provide sufficient concurrency for I/O-bound MCP requests.
+     Cloud Run scales horizontally for true parallelism. *)
+  let domain_mgr = None in
 
   (* Graceful shutdown setup *)
   let switch_ref = ref None in


### PR DESCRIPTION
## Problem
Cloud Run logs: Invalid_argument(Switch accessed from wrong domain) on tools/call requests.
Domain_manager.run dispatches to separate OS domains but net/clock/cohttp_client are main-domain bound.

## Fix
Set domain_mgr = None in start_server. MCP requests run on main domain with Eio fiber concurrency.

## Safe because
- I/O-bound requests (HTTP to Figma API), not CPU-bound
- Eio fibers = cooperative concurrency within single domain
- Stdio mode already works this way
- Cloud Run scales horizontally