### PR TITLE
fix: make figma_verify_visual concurrency-safe

### DIFF
--- a/lib/mcp_tools.ml
+++ b/lib/mcp_tools.ml
@@ -3727,8 +3727,12 @@ let handle_verify_visual args : (Yojson.Safe.t, string) result =
   match (file_key, node_id, token) with
   | (Some file_key, Some node_id, Some token) ->
       (* 1. Figma에서 노드 PNG 내보내기 *)
-      let figma_png_path = Printf.sprintf "/tmp/figma-visual/figma_%s_%s.png"
-        file_key (sanitize_node_id node_id) in
+      (* Use unique temp paths to avoid cross-run collisions. *)
+      let figma_png_path =
+        Visual_verifier.temp_file
+          ~prefix:(Printf.sprintf "figma_%s_%s" (sanitize_file_key file_key) (sanitize_node_id node_id))
+          ~ext:"png"
+      in
       (match Figma_effects.Perform.get_images ~token ~file_key
               ~node_ids:[node_id] ~format:"png" ~scale:1.0 ?version () with
        | Error err -> Error (Printf.sprintf "Failed to get Figma image: %s" err)

--- a/lib/visual_verifier.ml
+++ b/lib/visual_verifier.ml
@@ -34,8 +34,11 @@ let default_max_iterations = 5
 
 (** 디렉토리 생성 (존재하지 않으면) *)
 let ensure_dir path =
-  if not (Sys.file_exists path) then
-    Unix.mkdir path 0o755
+  if Sys.file_exists path then ()
+  else
+    (* Best-effort: in concurrent runs another fiber/process may have created it. *)
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
 
 (** 고유 파일명 생성 *)
 let generate_temp_filename ~prefix ~ext =
@@ -615,11 +618,21 @@ let result_to_json result =
 
 (** 진화 디렉토리 생성 *)
 let create_evolution_dir () =
-  let timestamp = Unix.gettimeofday () in
-  let dir = sprintf "/tmp/figma-evolution/run_%d" (int_of_float (timestamp *. 1000.0)) in
-  let html_dir = Filename.concat dir "html" in
-  mkdir_p html_dir;
-  dir
+  let base_dir = "/tmp/figma-evolution" in
+  ensure_dir base_dir;
+  let pid = Unix.getpid () in
+  let rec attempt tries =
+    let timestamp_ms = int_of_float (Unix.gettimeofday () *. 1000.0) in
+    let nonce = Random.int 1_000_000 in
+    let dir = sprintf "%s/run_%d_%d_%06d" base_dir timestamp_ms pid nonce in
+    try
+      Unix.mkdir dir 0o755;
+      ensure_dir (Filename.concat dir "html");
+      dir
+    with
+    | Unix.Unix_error (Unix.EEXIST, _, _) when tries < 25 -> attempt (tries + 1)
+  in
+  attempt 0
 
 (** HTML을 파일로 저장 *)
 let save_html ~dir ~step html =
@@ -657,7 +670,7 @@ let verify_visual
     ~figma_png
     html
   =
-  let evo_dir = if save_evolution then create_evolution_dir () else "/tmp/figma-visual" in
+  let evo_dir = if save_evolution then create_evolution_dir () else temp_dir in
 
   (* Figma 원본도 evolution 디렉토리에 복사 *)
   let _ =

--- a/test/test_visual_verifier.ml
+++ b/test/test_visual_verifier.ml
@@ -22,6 +22,23 @@ let test_ensure_dir () =
   (* 정리 - 실패해도 무시 *)
   (try Unix.rmdir test_dir with Unix.Unix_error _ -> ())
 
+let test_create_evolution_dir_unique () =
+  (* Ensure evolution dirs are unique even if called in quick succession. *)
+  let dir1 = Visual_verifier.create_evolution_dir () in
+  let dir2 = Visual_verifier.create_evolution_dir () in
+  check bool "unique dirs" true (dir1 <> dir2);
+  check bool "dir1 exists" true (Sys.file_exists dir1);
+  check bool "dir2 exists" true (Sys.file_exists dir2);
+  check bool "dir1 html exists" true (Sys.file_exists (Filename.concat dir1 "html"));
+  check bool "dir2 html exists" true (Sys.file_exists (Filename.concat dir2 "html"));
+  (* Best-effort cleanup (dirs should be empty). *)
+  let cleanup dir =
+    (try Unix.rmdir (Filename.concat dir "html") with Unix.Unix_error _ -> ());
+    (try Unix.rmdir dir with Unix.Unix_error _ -> ())
+  in
+  cleanup dir1;
+  cleanup dir2
+
 (** ============== Correction Hint 테스트 ============== *)
 
 let test_hint_to_json_padding () =
@@ -179,6 +196,7 @@ let test_render_html_to_png_basic () =
 let utility_tests = [
   "temp file generation", `Quick, test_temp_file_generation;
   "ensure dir", `Quick, test_ensure_dir;
+  "create evolution dir unique", `Quick, test_create_evolution_dir_unique;
 ]
 
 let hint_tests = [


### PR DESCRIPTION
## Summary
- Avoid tmp-path collisions in `figma_verify_visual` by using unique temp files.
- Make visual evolution run directories unique (timestamp+pid+nonce) and robust to mkdir races.
- Add a unit test to ensure evolution dir uniqueness + `html/` subdir creation.

## Why
Concurrent visual verification runs could overwrite fixed `/tmp` paths, producing flaky SSIM results or mixing artifacts.

## Tests
- `dune test --root . -f`