### PR TITLE
fix: propagate errors, narrow catch-all exceptions

### DIFF
--- a/lib/figma_cache.ml
+++ b/lib/figma_cache.ml
@@ -274,7 +274,8 @@ let get ~file_key ~node_id ?(options=[]) ?(ttl_hours=Config.ttl_hours) () =
                FS.delete_file cache_file;  (* 만료된 캐시 삭제 *)
                None
              )
-         | exception _ ->
+         | exception exn ->
+             eprintf "[Cache] L2 parse error for %s: %s\n%!" node_id (Printexc.to_string exn);
              Stats.record_miss ();
              FS.delete_file cache_file;
              None)

--- a/lib/figma_config.ml
+++ b/lib/figma_config.ml
@@ -16,12 +16,12 @@ let get_string ~default name =
 
 let get_int ~default name =
   match Sys.getenv_opt name with
-  | Some v -> (try int_of_string v with _ -> default)
+  | Some v -> (try int_of_string v with Failure _ -> default)
   | None -> default
 
 let get_float ~default name =
   match Sys.getenv_opt name with
-  | Some v -> (try float_of_string v with _ -> default)
+  | Some v -> (try float_of_string v with Failure _ -> default)
   | None -> default
 
 let get_bool ~default name =

--- a/lib/figma_crawl.ml
+++ b/lib/figma_crawl.ml
@@ -265,9 +265,12 @@ let crawl_file ~token ~neo4j_cfg ~progress ~options ~project_id ~file_key ~file_
   on_progress (sprintf "  📄 File: %s (%s)" file_name file_key);
 
   (* 파일 노드 생성 *)
-  let _ = create_figma_file ~neo4j_cfg
-    ~file_key ~name:file_name ~project_id ~last_modified
-  in
+  (match create_figma_file ~neo4j_cfg
+    ~file_key ~name:file_name ~project_id ~last_modified with
+   | Ok _ -> ()
+   | Error msg ->
+       on_progress (sprintf "  ⚠ create_figma_file(%s): %s" file_key msg);
+       progress.errors <- msg :: progress.errors);
   progress.files <- progress.files + 1;
 
   (* 파일 노드 트리 가져오기 *)
@@ -300,8 +303,9 @@ let crawl_file ~token ~neo4j_cfg ~progress ~options ~project_id ~file_key ~file_
             in
             match save_nodes_batch ~neo4j_cfg ~progress batch with
             | Ok () ->
-                let _ = save_node_relationships ~neo4j_cfg batch in
-                save_in_batches rest
+                (match save_node_relationships ~neo4j_cfg batch with
+                 | Ok () -> save_in_batches rest
+                 | Error _ as e -> e)
             | Error _ as e -> e
       in
       save_in_batches flat_nodes
@@ -316,9 +320,12 @@ let crawl_project ~token ~neo4j_cfg ~progress ~options ~team_id ~project_id ~pro
   on_progress (sprintf "📁 Project: %s (%s)" project_name project_id);
 
   (* 프로젝트 노드 생성 *)
-  let _ = create_figma_project ~neo4j_cfg
-    ~project_id ~name:project_name ~team_id
-  in
+  (match create_figma_project ~neo4j_cfg
+    ~project_id ~name:project_name ~team_id with
+   | Ok _ -> ()
+   | Error msg ->
+       on_progress (sprintf "  ⚠ create_figma_project(%s): %s" project_id msg);
+       progress.errors <- msg :: progress.errors);
   progress.projects <- progress.projects + 1;
 
   (* 파일 목록 가져오기 *)
@@ -334,8 +341,11 @@ let crawl_project ~token ~neo4j_cfg ~progress ~options ~team_id ~project_id ~pro
           crawl_file ~token ~neo4j_cfg ~progress ~options
             ~project_id ~file_key ~file_name ~last_modified ~on_progress
       ) files in
-      (* 에러가 있어도 계속 진행 *)
-      let _ = results in
+      (* 에러 수집 후 계속 진행 *)
+      List.iter (function
+        | Error msg -> progress.errors <- msg :: progress.errors
+        | Ok () -> ()
+      ) results;
       Ok ()
 
   | Error err ->
@@ -366,8 +376,12 @@ let crawl_team ~token ~team_id ~neo4j_cfg
        on_progress (sprintf "❌ Neo4j connection failed: %s" err);
        failwith err);
 
-  (* 팀 노드 생성 *)
-  let _ = create_figma_team ~neo4j_cfg ~team_id ~name:team_name in
+  (* 팀 노드 생성 — fatal: crawl cannot proceed without team *)
+  (match create_figma_team ~neo4j_cfg ~team_id ~name:team_name with
+   | Ok _ -> ()
+   | Error msg ->
+       on_progress (sprintf "❌ create_figma_team(%s) failed: %s" team_id msg);
+       failwith (sprintf "Team creation failed: %s" msg));
   progress.teams <- 1;
 
   (* 프로젝트 목록 가져오기 *)
@@ -377,12 +391,13 @@ let crawl_team ~token ~team_id ~neo4j_cfg
       on_progress (sprintf "Found %d projects" (List.length projects));
       on_progress "─────────────────────────────────────────";
 
-      (* 각 프로젝트 크롤링 *)
+      (* 각 프로젝트 크롤링 — per-project errors logged, crawl continues *)
       List.iter (fun (project_id, project_name) ->
-        let _ = crawl_project ~token ~neo4j_cfg ~progress ~options
-          ~team_id ~project_id ~project_name ~on_progress
-        in
-        ()
+        match crawl_project ~token ~neo4j_cfg ~progress ~options
+          ~team_id ~project_id ~project_name ~on_progress with
+        | Ok () -> ()
+        | Error msg ->
+            on_progress (sprintf "  ⚠ crawl_project(%s) failed: %s" project_id msg)
       ) projects;
 
       (* 결과 요약 *)

--- a/lib/mcp_protocol_eio.ml
+++ b/lib/mcp_protocol_eio.ml
@@ -730,7 +730,7 @@ type mcp_message_kind =
 
 let classify_message body_str =
   match Yojson.Safe.from_string body_str with
-  | exception _ -> `Unknown
+  | exception (Yojson.Json_error _) -> `Unknown
   | `Assoc fields ->
       let has_method = List.mem_assoc "method" fields in
       let id = List.assoc_opt "id" fields in
@@ -1384,7 +1384,7 @@ let rec generate_code_template ?(depth=0) node platform =
   in
   let w = member "width" node |> to_number |> int_of_float in
   let h = member "height" node |> to_number |> int_of_float in
-  let node_type = member "type" node |> to_string_option |> Option.value ~default:"FRAME" in
+  let _node_type = member "type" node |> to_string_option |> Option.value ~default:"FRAME" in
 
   (* Extract background color from fills *)
   let bg_color = match member "fills" node with
@@ -1468,8 +1468,6 @@ let rec generate_code_template ?(depth=0) node platform =
       ) (if child_count > 5 then List.filteri (fun i _ -> i < 5) children else children) in
       if List.length sub_defs = 0 then "" else "\n" ^ String.concat "\n" sub_defs
   in
-
-  let _ = node_type in (* suppress unused warning *)
 
   (* Extract auto-layout info *)
   let layout_mode = match member "autoLayout" node with
@@ -1686,15 +1684,13 @@ let plugin_analyze_handler ~sw:_ ~eio_ctx:_ _request reqd =
 
         (* Build analysis from node info *)
         let node_info = Yojson.Safe.to_string node in
-        let full_prompt = if prompt = "" then
+        let _full_prompt = if prompt = "" then
           sprintf "Analyze this Figma node and provide insights:\n%s\n\nProvide: 1) Structure overview, 2) Design patterns used, 3) Accessibility considerations, 4) Implementation recommendations." node_info
         else
           prompt
         in
 
-        (* Try llm-mcp, fallback to local analysis *)
         (* Local analysis - fast and reliable, no LLM dependency *)
-        let _ = full_prompt in (* suppress unused warning *)
         let to_number json = match json with
           | `Float f -> f | `Int i -> float_of_int i | _ -> 0.0
         in
@@ -2623,7 +2619,7 @@ let extract_variants_handler ~sw:_ ~eio_ctx:_ _request reqd =
     | Ok json ->
         let open Yojson.Safe.Util in
         let node = member "node" json in
-        let to_num json = match json with `Float f -> f | `Int i -> float_of_int i | _ -> 0.0 in
+        let _to_num json = match json with `Float f -> f | `Int i -> float_of_int i | _ -> 0.0 in
 
         (* Extract variant properties from component set or variants *)
         let variants = ref [] in
@@ -2698,7 +2694,6 @@ type %sVariant = {
           ("variants", `List variant_list);
           ("typescript", `String ts_types);
         ] in
-        let _ = to_num in (* suppress warning *)
         Response.json (Yojson.Safe.to_string result) reqd
   )
 

--- a/lib/mcp_tools.ml
+++ b/lib/mcp_tools.ml
@@ -1240,7 +1240,7 @@ let has_node_module name =
 (** mkdir_p: moved to mcp_helpers.ml *)
 
 let normalize_path path =
-  try Some (Unix.realpath path) with _ -> None
+  try Some (Unix.realpath path) with Unix.Unix_error _ -> None
 
 let is_under_dir ~dir path =
   match (normalize_path dir, normalize_path path) with

--- a/lib/mcp_visual_handlers.ml
+++ b/lib/mcp_visual_handlers.ml
@@ -880,8 +880,12 @@ let handle_compare_regions args : (Yojson.Safe.t, string) result =
                         (* ImageMagick으로 영역 crop *)
                         let args_a = [| "magick"; image_a; "-crop"; Printf.sprintf "%dx%d+%d+%d" w h x y; "+repage"; crop_a |] in
                         let args_b = [| "magick"; image_b; "-crop"; Printf.sprintf "%dx%d+%d+%d" w h x y; "+repage"; crop_b |] in
-                        let _ = Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "magick" args_a in
-                        let _ = Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "magick" args_b in
+                        (match Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "magick" args_a with
+                         | Error msg -> Printf.eprintf "[visual] magick crop A failed: %s\n%!" msg
+                         | Ok _ -> ());
+                        (match Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "magick" args_b with
+                         | Error msg -> Printf.eprintf "[visual] magick crop B failed: %s\n%!" msg
+                         | Ok _ -> ());
 
                         (* SSIM 계산 *)
                         let args_ssim = [| "magick"; "compare"; "-metric"; "SSIM"; crop_a; crop_b; "null:" |] in
@@ -913,7 +917,9 @@ let handle_compare_regions args : (Yojson.Safe.t, string) result =
                           if generate_diff then begin
                             let diff_path = Filename.concat output_dir (Printf.sprintf "diff_%s.png" name) in
                             let args_diff = [| "magick"; "compare"; crop_a; crop_b; diff_path |] in
-                            let _ = Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "magick" args_diff in
+                            (match Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "magick" args_diff with
+                             | Error msg -> Printf.eprintf "[visual] magick compare failed: %s\n%!" msg
+                             | Ok _ -> ());
                             Some diff_path
                           end else None
                         in
@@ -1044,7 +1050,9 @@ let handle_evolution_report args : (Yojson.Safe.t, string) result =
             let output = Filename.concat dir "evolution_comparison.png" in
             if Sys.file_exists figma_png && Sys.file_exists last_png then
               let args = [| "montage"; figma_png; last_png; "-tile"; "2x1"; "-geometry"; "+5+5"; "-background"; "#1a1a1a"; output |] in
-              let _ = Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "montage" args in
+              (match Safe_exec.run_stdout ~timeout_ms:20000 ~output_limit:(64 * 1024) "montage" args with
+               | Error msg -> Printf.eprintf "[visual] montage failed: %s\n%!" msg
+               | Ok _ -> ());
               if Sys.file_exists output then Some output else None
             else None
           else None

--- a/lib/neo4j_client.ml
+++ b/lib/neo4j_client.ml
@@ -206,46 +206,52 @@ let create_figma_team ~sw ~env client ~team_id ~name =
 
 (** Figma 프로젝트 노드 생성 *)
 let create_figma_project ~sw ~env client ~project_id ~name ~team_id =
-  let _ = merge_node ~sw ~env client "FigmaProject" ("id", `String project_id) [
+  match merge_node ~sw ~env client "FigmaProject" ("id", `String project_id) [
     ("id", `String project_id);
     ("name", `String name);
-  ] in
-  create_relationship ~sw ~env client
-    ~from_label:"FigmaTeam" ~from_key:"id" ~from_value:(`String team_id)
-    ~to_label:"FigmaProject" ~to_key:"id" ~to_value:(`String project_id)
-    ~rel_type:"HAS_PROJECT"
+  ] with
+  | Error _ as e -> e
+  | Ok _ ->
+      create_relationship ~sw ~env client
+        ~from_label:"FigmaTeam" ~from_key:"id" ~from_value:(`String team_id)
+        ~to_label:"FigmaProject" ~to_key:"id" ~to_value:(`String project_id)
+        ~rel_type:"HAS_PROJECT"
 
 (** Figma 파일 노드 생성 *)
 let create_figma_file ~sw ~env client ~file_key ~name ~project_id ~last_modified =
-  let _ = merge_node ~sw ~env client "FigmaFile" ("key", `String file_key) [
+  match merge_node ~sw ~env client "FigmaFile" ("key", `String file_key) [
     ("key", `String file_key);
     ("name", `String name);
     ("last_modified", `String last_modified);
-  ] in
-  create_relationship ~sw ~env client
-    ~from_label:"FigmaProject" ~from_key:"id" ~from_value:(`String project_id)
-    ~to_label:"FigmaFile" ~to_key:"key" ~to_value:(`String file_key)
-    ~rel_type:"HAS_FILE"
+  ] with
+  | Error _ as e -> e
+  | Ok _ ->
+      create_relationship ~sw ~env client
+        ~from_label:"FigmaProject" ~from_key:"id" ~from_value:(`String project_id)
+        ~to_label:"FigmaFile" ~to_key:"key" ~to_value:(`String file_key)
+        ~rel_type:"HAS_FILE"
 
 (** Figma 노드 생성 *)
 let create_figma_node ~sw ~env client ~node_id ~name ~node_type ~file_key ~parent_id =
-  let _ = merge_node ~sw ~env client "FigmaNode" ("id", `String node_id) [
+  match merge_node ~sw ~env client "FigmaNode" ("id", `String node_id) [
     ("id", `String node_id);
     ("name", `String name);
     ("type", `String node_type);
     ("file_key", `String file_key);
-  ] in
-  match parent_id with
-  | Some pid ->
-      create_relationship ~sw ~env client
-        ~from_label:"FigmaNode" ~from_key:"id" ~from_value:(`String pid)
-        ~to_label:"FigmaNode" ~to_key:"id" ~to_value:(`String node_id)
-        ~rel_type:"HAS_CHILD"
-  | None ->
-      create_relationship ~sw ~env client
-        ~from_label:"FigmaFile" ~from_key:"key" ~from_value:(`String file_key)
-        ~to_label:"FigmaNode" ~to_key:"id" ~to_value:(`String node_id)
-        ~rel_type:"HAS_NODE"
+  ] with
+  | Error _ as e -> e
+  | Ok _ ->
+      (match parent_id with
+       | Some pid ->
+           create_relationship ~sw ~env client
+             ~from_label:"FigmaNode" ~from_key:"id" ~from_value:(`String pid)
+             ~to_label:"FigmaNode" ~to_key:"id" ~to_value:(`String node_id)
+             ~rel_type:"HAS_CHILD"
+       | None ->
+           create_relationship ~sw ~env client
+             ~from_label:"FigmaFile" ~from_key:"key" ~from_value:(`String file_key)
+             ~to_label:"FigmaNode" ~to_key:"id" ~to_value:(`String node_id)
+             ~rel_type:"HAS_NODE")
 
 (** 배치로 Figma 노드들 생성 (성능 최적화) *)
 let batch_create_figma_nodes ~sw ~env client nodes =


### PR DESCRIPTION
## Summary

- **neo4j_client.ml**: Propagate `merge_node` errors via `Result.bind` pattern instead of `let _ =` (3 locations)
- **figma_crawl.ml**: Context-appropriate error handling — fatal for team creation, logged+collected for file/project, propagated for relationships (6 locations)
- **mcp_visual_handlers.ml**: Log ImageMagick failures instead of silently discarding (4 locations)
- **figma_cache.ml**: Add `Printexc.to_string` logging to L2 parse catch-all
- **mcp_protocol_eio.ml**: Narrow `exception _` to `Yojson.Json_error`, clean unused params (3 locations)
- **figma_config.ml**: Narrow catch-all to `Failure _` in int/float parsers (2 locations)
- **mcp_tools.ml**: Narrow catch-all to `Unix.Unix_error _` in stat check (1 location)

**7 files, 84 insertions, 59 deletions.** All 29 tests pass.

## Test plan

- [x] `dune build` — zero errors
- [x] `dune runtest --force` — all tests pass (29/29)
- [x] `git diff --stat` — only intended 7 files changed
- [ ] Coverage check with bisect_ppx (no regression expected)
- [ ] Smoke test: start server, curl wired endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)