### PR TITLE
feat(cache): reduce default node cache TTL from 24h to 8h

### DIFF
--- a/lib/figma_config.ml
+++ b/lib/figma_config.ml
@@ -54,7 +54,7 @@ module Cache = struct
 
   (** TTL for general cache entries (hours) *)
   let ttl_hours =
-    get_float ~default:24.0 "FIGMA_MCP_CACHE_TTL_HOURS"
+    get_float ~default:8.0 "FIGMA_MCP_CACHE_TTL_HOURS"
 
   (** TTL for variable cache entries (hours) *)
   let ttl_variables_hours =


### PR DESCRIPTION
## Summary\nReduce the default general cache TTL from 24 hours to 8 hours.\n\n## Motivation\nWhen integrated with kidsnote-ax-tf Figma search, 24h cache causes stale design results. Figma designs typically change within a workday, so 8h balances freshness with API rate limiting.\n\n## Changes\n| Cache Type | Before | After | Env Override |\n|-----------|--------|-------|-------------|\n| General (Nodes) | 24h | **8h** | FIGMA_MCP_CACHE_TTL_HOURS |\n| Variables | 1h | 1h (unchanged) | FIGMA_MCP_CACHE_TTL_VARIABLES_HOURS |\n| Search | 30min | 30min (unchanged) | FIGMA_MCP_CACHE_TTL_SEARCH_HOURS |\n\nExisting deployments with FIGMA_MCP_CACHE_TTL_HOURS set explicitly are unaffected.