### PR TITLE
feat(api): Eio.Semaphore concurrency limiter for Figma API

### DIFF
--- a/lib/figma_api_eio.ml
+++ b/lib/figma_api_eio.ml
@@ -281,6 +281,7 @@ type client = {
   cohttp_client : Cohttp_eio.Client.t;  (** LLM provider 등 호환용 *)
   raw_pool : (string, raw_conn) Hashtbl.t;
   raw_pool_lock : Eio.Mutex.t;
+  api_limiter : Eio.Semaphore.t;  (** max concurrent Figma API calls *)
 }
 
 (** TLS 설정 생성 *)
@@ -305,7 +306,7 @@ let make_cohttp_https_handler tls_config =
     Tls_eio.client_of_flow tls_config ~host:host_domain tcp_flow)
 
 (** HTTP 클라이언트 생성 *)
-let make_client (net : _ Eio.Net.t) : client =
+let make_client ?(max_concurrent_api=3) (net : _ Eio.Net.t) : client =
   let tls_config = make_tls_config () in
   let https = make_cohttp_https_handler tls_config in
   let cohttp_client = Cohttp_eio.Client.make ~https net in
@@ -314,6 +315,7 @@ let make_client (net : _ Eio.Net.t) : client =
     cohttp_client;
     raw_pool = Hashtbl.create 4;
     raw_pool_lock = Eio.Mutex.create ();
+    api_limiter = Eio.Semaphore.make max_concurrent_api;
   }
 
 (** Cohttp 클라이언트 추출 (LLM provider 등 호환용) *)
@@ -908,22 +910,34 @@ let with_smart_retry ~clock ?(max_retries=2) f =
   in
   loop 0
 
-(** GET 요청 with smart retry *)
+(** Concurrency limiter: acquire slot before API call, release after completion.
+    Holds slot during retry backoff to prevent 429 cascade. *)
+let with_api_limiter client f =
+  Eio.Semaphore.acquire client.api_limiter;
+  Fun.protect f ~finally:(fun () -> Eio.Semaphore.release client.api_limiter)
+
+(** GET 요청 with smart retry + concurrency limit *)
 let get_json_with_retry ~sw ~net ~clock ~client ~token ?(max_retries=2) url =
-  with_smart_retry ~clock ~max_retries (fun () ->
-    get_json ~sw ~net ~clock ~client ~token url
+  with_api_limiter client (fun () ->
+    with_smart_retry ~clock ~max_retries (fun () ->
+      get_json ~sw ~net ~clock ~client ~token url
+    )
   )
 
-(** POST 요청 with smart retry *)
+(** POST 요청 with smart retry + concurrency limit *)
 let post_json_with_retry ~sw ~net ~clock ~client ~token ?(max_retries=2) url body_json =
-  with_smart_retry ~clock ~max_retries (fun () ->
-    post_json ~sw ~net ~clock ~client ~token url body_json
+  with_api_limiter client (fun () ->
+    with_smart_retry ~clock ~max_retries (fun () ->
+      post_json ~sw ~net ~clock ~client ~token url body_json
+    )
   )
 
-(** 다운로드 with smart retry *)
+(** 다운로드 with smart retry + concurrency limit *)
 let download_url_with_retry ~sw ~net ~clock ~client ~url ~path ?(max_retries=2) () =
-  with_smart_retry ~clock ~max_retries (fun () ->
-    download_url ~sw ~net ~clock ~client ~url ~path
+  with_api_limiter client (fun () ->
+    with_smart_retry ~clock ~max_retries (fun () ->
+      download_url ~sw ~net ~clock ~client ~url ~path
+    )
   )
 
 (** ============== JSON Utilities ============== *)

--- a/test/dune
+++ b/test/dune
@@ -192,6 +192,12 @@
  (name test_server_metrics)
  (libraries figma_mcp alcotest eio_main))
 
+; API rate limiter: Eio.Semaphore concurrency bounds
+(test
+ (name test_api_rate_limiter)
+ (libraries figma_mcp alcotest eio_main)
+ (action (run %{test} --color=always)))
+
 ; Category tools: list/describe/call behavior
 (test
  (name test_category_tools)

--- a/test/test_api_rate_limiter.ml
+++ b/test/test_api_rate_limiter.ml
@@ -1,0 +1,88 @@
+(** Test: Eio.Semaphore-based API rate limiter in figma_api_eio.ml
+
+    Spawns 5 concurrent fibers through a semaphore limited to 2 slots.
+    Verifies that at no point more than 2 fibers execute simultaneously. *)
+
+open Alcotest
+
+let test_concurrency_bounded_by_semaphore () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:2 net in
+
+  (* Shared atomic counters for lock-free concurrency tracking *)
+  let current = Atomic.make 0 in
+  let peak = Atomic.make 0 in
+  let violations = Atomic.make 0 in
+
+  let task _i =
+    Figma_api_eio.with_api_limiter client (fun () ->
+      let c = Atomic.fetch_and_add current 1 + 1 in
+      (* CAS loop to update peak *)
+      let rec update_peak () =
+        let old_peak = Atomic.get peak in
+        if c > old_peak then
+          if not (Atomic.compare_and_set peak old_peak c) then update_peak ()
+      in
+      update_peak ();
+      if c > 2 then Atomic.incr violations;
+      (* Hold the slot long enough for other fibers to contend *)
+      Eio.Time.sleep clock 0.05;
+      ignore (Atomic.fetch_and_add current (-1)))
+  in
+
+  Eio.Fiber.all
+    [ (fun () -> task 0)
+    ; (fun () -> task 1)
+    ; (fun () -> task 2)
+    ; (fun () -> task 3)
+    ; (fun () -> task 4)
+    ];
+
+  let peak_val = Atomic.get peak in
+  let violation_count = Atomic.get violations in
+
+  check int "no concurrency violations" 0 violation_count;
+  check bool "peak concurrency <= 2" true (peak_val <= 2);
+  check bool "peak concurrency >= 1 (sanity)" true (peak_val >= 1)
+
+let test_single_slot_serializes () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:1 net in
+
+  let current = Atomic.make 0 in
+  let peak = Atomic.make 0 in
+
+  let task _i =
+    Figma_api_eio.with_api_limiter client (fun () ->
+      let c = Atomic.fetch_and_add current 1 + 1 in
+      let rec update_peak () =
+        let old_peak = Atomic.get peak in
+        if c > old_peak then
+          if not (Atomic.compare_and_set peak old_peak c) then update_peak ()
+      in
+      update_peak ();
+      Eio.Time.sleep clock 0.02;
+      ignore (Atomic.fetch_and_add current (-1)))
+  in
+
+  Eio.Fiber.all
+    [ (fun () -> task 0)
+    ; (fun () -> task 1)
+    ; (fun () -> task 2)
+    ];
+
+  check int "peak concurrency is exactly 1" 1 (Atomic.get peak)
+
+let () =
+  run "api_rate_limiter"
+    [ ( "concurrency"
+      , [ test_case "bounded by semaphore (max=2, fibers=5)" `Quick
+            test_concurrency_bounded_by_semaphore
+        ; test_case "single slot serializes (max=1, fibers=3)" `Quick
+            test_single_slot_serializes
+        ] )
+    ]


### PR DESCRIPTION
## Problem

figma-mcp has no concurrency control on Figma API calls. When multiple MCP tools fire concurrently (e.g., search across N files), all requests hit Figma simultaneously, triggering HTTP 429 rate limits. The retry logic then amplifies the problem (N requests x M retries), causing a cascade that can block all Figma operations via circuit breaker.

## Solution

Add `Eio.Semaphore` to the `client` record to limit concurrent Figma API calls (default: 3).

### Changes
- `api_limiter : Eio.Semaphore.t` field in `client` record
- `make_client` accepts `?max_concurrent_api` (default: 3)
- `with_api_limiter` wraps the retry loop (`with_smart_retry`), holding the semaphore slot during backoff to prevent other requests from hitting the same rate window
- Applied to all three API chokepoints: `get_json_with_retry`, `post_json_with_retry`, `download_url_with_retry`

### Why hold slot during retry backoff?
If we released the slot during backoff sleep, other fibers would immediately fill it and likely get 429'd too. Holding the slot is protective -- it naturally throttles when Figma signals rate limiting.

### Trade-off
- Pro: prevents 429 cascade, reduces wasted API calls
- Con: under heavy load, fibers queue on the semaphore (fiber suspension, not thread blocking)
- Default 3 is conservative; tunable via `?max_concurrent_api`

## Tests
- `test_api_rate_limiter`: 2 tests verifying concurrency bounds (max=2 with 5 fibers, max=1 with 3 fibers)
- All existing tests pass (0 regressions)
