### PR TITLE
fix(sse): compact JSON to single line before SSE framing

### DIFF
--- a/lib/mcp_protocol_eio.ml
+++ b/lib/mcp_protocol_eio.ml
@@ -582,9 +582,14 @@ module Response = struct
 
   (** SSE single message response for POST→SSE (MCP Streamable HTTP) *)
   let sse_message ?(session_id="") json_str reqd =
+    (* Ensure JSON is single-line to prevent SSE frame corruption *)
+    let safe_json = match Yojson.Safe.from_string json_str with
+      | json -> Yojson.Safe.to_string json
+      | exception (Yojson.Json_error _) -> json_str
+    in
     let event_id = Printf.sprintf "s%d-%d" (Unix.getpid ()) (Random.int 10000) in
     let prime = Printf.sprintf "retry: 5000\nid: %s:2\n\n" event_id in
-    let message = Printf.sprintf "id: %s:1\ndata: %s\n\n" event_id json_str in
+    let message = Printf.sprintf "id: %s:1\ndata: %s\n\n" event_id safe_json in
     let body = prime ^ message in
     let session_headers = if session_id = "" then [] else [("mcp-session-id", session_id)] in
     let headers = Httpun.Headers.of_list ([
@@ -784,14 +789,26 @@ let random_sse_client_id () =
   in
   loop ()
 
+(** Re-serialize JSON string to compact single-line form.
+    Prevents multi-line data: fields in SSE output.
+    Returns original string unchanged if not valid JSON. *)
+let compact_json_string s =
+  match Yojson.Safe.from_string s with
+  | json -> Yojson.Safe.to_string json
+  | exception (Yojson.Json_error _) -> s
+
 let format_sse_data data =
   if data = "" then
     "data: "
   else
-    data
-    |> String.split_on_char '\n'
-    |> List.map (fun line -> "data: " ^ line)
-    |> String.concat "\n"
+    (* Compact JSON to single line to avoid multi-line data: split *)
+    let compacted = compact_json_string data in
+    if not (String.contains compacted '\n') then
+      "data: " ^ compacted
+    else
+      (* Non-JSON multi-line: split per SSE spec *)
+      let lines = String.split_on_char '\n' compacted in
+      String.concat "\n" (List.map (fun line -> "data: " ^ line) lines)
 
 let register_sse_client body =
   let id = random_sse_client_id () in

--- a/test/test_mcp_protocol_coverage.ml
+++ b/test/test_mcp_protocol_coverage.ml
@@ -640,6 +640,24 @@ module Eio_tests = struct
     let result = Mcp_protocol_eio.format_sse_data "" in
     check string "empty data" "data: " result
 
+  let test_format_sse_data_json_compact () =
+    (* Pretty-printed JSON should be compacted to single line *)
+    let pretty_json = "{\n  \"result\": {\n    \"content\": []\n  }\n}" in
+    let result = Mcp_protocol_eio.format_sse_data pretty_json in
+    check string "json compact" "data: {\"result\":{\"content\":[]}}" result
+
+  let test_compact_json_string_valid () =
+    let result = Mcp_protocol_eio.compact_json_string "{\n  \"a\": 1\n}" in
+    check string "valid json" "{\"a\":1}" result
+
+  let test_compact_json_string_invalid () =
+    let result = Mcp_protocol_eio.compact_json_string "not json" in
+    check string "invalid json" "not json" result
+
+  let test_compact_json_string_already_compact () =
+    let result = Mcp_protocol_eio.compact_json_string "{\"b\":2}" in
+    check string "already compact" "{\"b\":2}" result
+
   (** --- Config --- *)
 
   let test_default_config () =
@@ -883,6 +901,10 @@ let eio_tests = [
   "format_sse_data single line", `Quick, Eio_tests.test_format_sse_data_single_line;
   "format_sse_data multiline", `Quick, Eio_tests.test_format_sse_data_multiline;
   "format_sse_data empty", `Quick, Eio_tests.test_format_sse_data_empty;
+  "format_sse_data json compact", `Quick, Eio_tests.test_format_sse_data_json_compact;
+  "compact_json_string valid", `Quick, Eio_tests.test_compact_json_string_valid;
+  "compact_json_string invalid", `Quick, Eio_tests.test_compact_json_string_invalid;
+  "compact_json_string already compact", `Quick, Eio_tests.test_compact_json_string_already_compact;
 
   (* Config *)
   "default_config", `Quick, Eio_tests.test_default_config;


### PR DESCRIPTION
## Summary
- Pretty-printed JSON with newlines caused multi-line `data:` fields in SSE output
- Some MCP clients (Python `json.loads`) fail to reassemble split `data:` lines
- Fix both SSE output paths: `format_sse_data` (GET SSE stream) and `sse_message` (POST→SSE)
- Add `compact_json_string` helper: re-serialize via Yojson to strip newlines, passthrough non-JSON

## Changes
- `lib/mcp_protocol_eio.ml`: 2 SSE output paths now compact JSON before framing
- `test/test_mcp_protocol_coverage.ml`: +4 tests (compact valid, invalid, already-compact, format_sse_data json)

## Test plan
- [x] 969 existing tests pass (0 regressions)
- [x] 4 new tests for compact_json_string and format_sse_data JSON compaction
- [x] Non-JSON multi-line input still splits per SSE spec (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)