### PR TITLE
feat(api): add in-flight request deduplication

### DIFF
--- a/lib/figma_api_eio.ml
+++ b/lib/figma_api_eio.ml
@@ -282,6 +282,8 @@ type client = {
   raw_pool : (string, raw_conn) Hashtbl.t;
   raw_pool_lock : Eio.Mutex.t;
   api_limiter : Eio.Semaphore.t;  (** max concurrent Figma API calls *)
+  inflight : (string, ((Yojson.Safe.t, api_error) result, exn) result Eio.Promise.t) Hashtbl.t;
+  inflight_lock : Eio.Mutex.t;
 }
 
 (** TLS 설정 생성 *)
@@ -316,6 +318,8 @@ let make_client ?(max_concurrent_api=3) (net : _ Eio.Net.t) : client =
     raw_pool = Hashtbl.create 4;
     raw_pool_lock = Eio.Mutex.create ();
     api_limiter = Eio.Semaphore.make max_concurrent_api;
+    inflight = Hashtbl.create 16;
+    inflight_lock = Eio.Mutex.create ();
   }
 
 (** Cohttp 클라이언트 추출 (LLM provider 등 호환용) *)
@@ -916,11 +920,46 @@ let with_api_limiter client f =
   Eio.Semaphore.acquire client.api_limiter;
   Fun.protect f ~finally:(fun () -> Eio.Semaphore.release client.api_limiter)
 
-(** GET 요청 with smart retry + concurrency limit *)
+(** Coalesce concurrent GET requests for the same URL.
+    If a request for [key] is already in-flight, the caller waits for
+    its result instead of issuing a duplicate HTTP call.
+    Runs OUTSIDE the semaphore so joiners consume no concurrency slot. *)
+let dedup_get client key compute =
+  let action = Eio.Mutex.use_rw ~protect:true client.inflight_lock (fun () ->
+    match Hashtbl.find_opt client.inflight key with
+    | Some promise -> `Join promise
+    | None ->
+      let promise, resolver = Eio.Promise.create () in
+      Hashtbl.replace client.inflight key promise;
+      `Lead resolver
+  ) in
+  match action with
+  | `Join promise ->
+    (match Eio.Promise.await promise with
+     | Ok v -> v
+     | Error exn -> raise exn)
+  | `Lead resolver ->
+    match compute () with
+    | v ->
+      Eio.Mutex.use_rw ~protect:true client.inflight_lock (fun () ->
+        Hashtbl.remove client.inflight key
+      );
+      Eio.Promise.resolve resolver (Ok v);
+      v
+    | exception exn ->
+      Eio.Mutex.use_rw ~protect:true client.inflight_lock (fun () ->
+        Hashtbl.remove client.inflight key
+      );
+      Eio.Promise.resolve resolver (Error exn);
+      raise exn
+
+(** GET 요청 with dedup + concurrency limit + smart retry *)
 let get_json_with_retry ~sw ~net ~clock ~client ~token ?(max_retries=2) url =
-  with_api_limiter client (fun () ->
-    with_smart_retry ~clock ~max_retries (fun () ->
-      get_json ~sw ~net ~clock ~client ~token url
+  dedup_get client url (fun () ->
+    with_api_limiter client (fun () ->
+      with_smart_retry ~clock ~max_retries (fun () ->
+        get_json ~sw ~net ~clock ~client ~token url
+      )
     )
   )
 

--- a/test/dune
+++ b/test/dune
@@ -198,6 +198,12 @@
  (libraries figma_mcp alcotest eio_main)
  (action (run %{test} --color=always)))
 
+; Request deduplication: in-flight coalescing via Eio.Promise
+(test
+ (name test_request_dedup)
+ (libraries figma_mcp alcotest eio_main)
+ (action (run %{test} --color=always)))
+
 ; Category tools: list/describe/call behavior
 (test
  (name test_category_tools)

--- a/test/test_request_dedup.ml
+++ b/test/test_request_dedup.ml
@@ -1,0 +1,167 @@
+(** Test: In-flight request deduplication in figma_api_eio.ml
+
+    Verifies that concurrent GET requests for the same URL are coalesced
+    into a single HTTP call, with joiners receiving the leader's result. *)
+
+open Alcotest
+
+(** dedup_get coalesces: 5 fibers requesting the same key,
+    only 1 compute executes, all get the same result. *)
+let test_dedup_coalesces () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:3 net in
+
+  let compute_count = Atomic.make 0 in
+
+  let task _i =
+    Figma_api_eio.dedup_get client "same-url" (fun () ->
+      ignore (Atomic.fetch_and_add compute_count 1);
+      (* Hold long enough for other fibers to join *)
+      Eio.Time.sleep clock 0.05;
+      Ok (`Assoc [("status", `String "ok")]))
+  in
+
+  let results = Array.make 5 (Error (Figma_api_eio.Http_error (0, "", None))) in
+  Eio.Fiber.all
+    (List.init 5 (fun i -> fun () ->
+       results.(i) <- task i));
+
+  (* Only 1 compute should have run *)
+  check int "compute ran exactly once" 1 (Atomic.get compute_count);
+
+  (* All fibers got Ok *)
+  Array.iteri (fun i r ->
+    match r with
+    | Ok _ -> ()
+    | Error _ ->
+      fail (Printf.sprintf "fiber %d got Error, expected Ok" i)
+  ) results
+
+(** Different keys run independently, not coalesced. *)
+let test_dedup_different_keys_independent () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:5 net in
+
+  let compute_count = Atomic.make 0 in
+
+  let task key =
+    Figma_api_eio.dedup_get client key (fun () ->
+      ignore (Atomic.fetch_and_add compute_count 1);
+      Eio.Time.sleep clock 0.02;
+      Ok (`String key))
+  in
+
+  Eio.Fiber.all
+    [ (fun () -> ignore (task "url-a"))
+    ; (fun () -> ignore (task "url-b"))
+    ; (fun () -> ignore (task "url-c"))
+    ];
+
+  check int "each key triggers its own compute" 3 (Atomic.get compute_count)
+
+(** Error from leader propagates to all joiners via raise. *)
+let test_dedup_error_propagation () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:3 net in
+
+  let compute_count = Atomic.make 0 in
+
+  let task _i =
+    try
+      let _ : (Yojson.Safe.t, Figma_api_eio.api_error) result =
+        Figma_api_eio.dedup_get client "fail-url" (fun () ->
+          ignore (Atomic.fetch_and_add compute_count 1);
+          Eio.Time.sleep clock 0.05;
+          raise (Failure "network down"))
+      in
+      `Ok
+    with Failure msg -> `Failed msg
+  in
+
+  let results = Array.make 3 `Ok in
+  Eio.Fiber.all
+    (List.init 3 (fun i -> fun () ->
+       results.(i) <- task i));
+
+  check int "compute ran exactly once" 1 (Atomic.get compute_count);
+
+  Array.iteri (fun i r ->
+    match r with
+    | `Failed msg ->
+      check string (Printf.sprintf "fiber %d got correct error" i) "network down" msg
+    | `Ok ->
+      fail (Printf.sprintf "fiber %d should have raised, got Ok" i)
+  ) results
+
+(** After completion, inflight entry is cleaned up.
+    A second call triggers a new compute. *)
+let test_dedup_cleanup_after_completion () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let _clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:3 net in
+
+  let compute_count = Atomic.make 0 in
+
+  let call () =
+    Figma_api_eio.dedup_get client "reuse-url" (fun () ->
+      ignore (Atomic.fetch_and_add compute_count 1);
+      Ok (`String "done"))
+  in
+
+  (* First call *)
+  let _ = call () in
+  check int "first call triggered compute" 1 (Atomic.get compute_count);
+
+  (* Second call — key was cleaned up, so this triggers a new compute *)
+  let _ = call () in
+  check int "second call triggered new compute" 2 (Atomic.get compute_count)
+
+(** Result-level errors (Ok/Error) are passed through, not raised. *)
+let test_dedup_result_error_passthrough () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let client = Figma_api_eio.make_client ~max_concurrent_api:3 net in
+
+  let task _i =
+    Figma_api_eio.dedup_get client "err-result-url" (fun () ->
+      Eio.Time.sleep clock 0.03;
+      Error (Figma_api_eio.Http_error (429, "rate limited", None)))
+  in
+
+  let results =
+    Array.make 3 (Ok (`Null) : (Yojson.Safe.t, Figma_api_eio.api_error) result)
+  in
+  Eio.Fiber.all
+    (List.init 3 (fun i -> fun () ->
+       results.(i) <- task i));
+
+  Array.iteri (fun i r ->
+    match r with
+    | Error (Figma_api_eio.Http_error (429, _, _)) -> ()
+    | _ ->
+      fail (Printf.sprintf "fiber %d expected HttpError 429" i)
+  ) results
+
+let () =
+  run "request_dedup"
+    [ ( "dedup"
+      , [ test_case "concurrent same-key coalesces to 1 compute" `Quick
+            test_dedup_coalesces
+        ; test_case "different keys run independently" `Quick
+            test_dedup_different_keys_independent
+        ; test_case "exception propagates to all joiners" `Quick
+            test_dedup_error_propagation
+        ; test_case "inflight cleaned up after completion" `Quick
+            test_dedup_cleanup_after_completion
+        ; test_case "result-level Error passes through (not raised)" `Quick
+            test_dedup_result_error_passthrough
+        ] )
+    ]


### PR DESCRIPTION
## Summary

- 동일 URL에 대한 동시 GET 요청을 `Eio.Promise` 기반으로 단일 HTTP 호출로 병합
- Leader/Joiner 패턴: 첫 요청이 leader, 후속 요청은 joiner로 promise를 대기
- 파이프라인 순서: `dedup → semaphore → retry → HTTP` (joiner는 semaphore 슬롯 미소비)
- `client` 레코드에 `inflight` 해시테이블 + `inflight_lock` 뮤텍스 추가

## Design

```
Fiber A ─┐                    ┌─ Ok result
         ├─ dedup_get ──┐     │
Fiber B ─┤              │     ├─ Ok result (same)
         ├─ (join) ─────┤     │
Fiber C ─┘              └─────┘
                    1 HTTP call
```

- `dedup_get` 내부에서 `Eio.Mutex`로 inflight 테이블 접근 보호
- 완료/실패 시 inflight 엔트리 즉시 제거 (후속 호출은 새 compute 실행)
- 예외(Eio cancellation 등)는 `(_, exn) result` 외부 레이어로 전파

## Test plan

- [x] `test_dedup_coalesces` — 동일 키 5개 fiber → compute 1회만 실행
- [x] `test_dedup_different_keys_independent` — 다른 키는 독립 compute
- [x] `test_dedup_error_propagation` — leader 예외가 모든 joiner에 전파
- [x] `test_dedup_cleanup_after_completion` — 완료 후 키 제거, 재호출 시 새 compute
- [x] `test_dedup_result_error_passthrough` — Result Error는 raise 아닌 값 전달
- [x] 전체 974 tests 통과 (기존 969 + 신규 5)

Generated with [Claude Code](https://claude.com/claude-code)