### PR TITLE
refactor: replace runtime failwith calls with typed exceptions

### DIFF
--- a/lib/figma_api_eio.ml
+++ b/lib/figma_api_eio.ml
@@ -21,6 +21,9 @@ let string_contains s sub =
 (** 타임아웃 예외 - 내부에서만 사용 *)
 exception Request_timeout
 
+(** 연결 실패 예외 - DNS 해석 실패, 비-TCP 주소 등 *)
+exception Connection_failed of string
+
 type api_error =
   | Http_error of int * string * float option  (** HTTP 상태 코드 + 메시지 + Retry-After *)
   | Json_error of string         (** JSON 파싱 에러 *)
@@ -598,19 +601,16 @@ let resolve_host_with_fallback ~sw ~net ~tls_config ~hostname ~port =
        | None -> None)
 
 let open_raw_connection ~sw ~net ~client ~hostname ~port =
-  let addr =
-    match resolve_host_with_fallback ~sw ~net ~tls_config:client.tls_config ~hostname ~port with
-    | Some addr ->
-        (match addr with
-         | `Tcp (ip, _) -> `Tcp (ip, port)
-         | _ -> failwith "Expected TCP address")
-    | None -> failwith (sprintf "DNS resolution failed for %s" hostname)
-  in
-  let tcp_flow = Eio.Net.connect ~sw net addr in
-  let host_domain = Domain_name.(host_exn (of_string_exn hostname)) in
-  let tls_flow = Tls_eio.client_of_flow client.tls_config ~host:host_domain tcp_flow in
-  let buf = Eio.Buf_read.of_flow ~max_size:max_body_size tls_flow in
-  { flow = tls_flow; buf; last_used = Unix.gettimeofday () }
+  match resolve_host_with_fallback ~sw ~net ~tls_config:client.tls_config ~hostname ~port with
+  | None -> Error (sprintf "DNS resolution failed for %s" hostname)
+  | Some (`Tcp (ip, _)) ->
+      let addr = `Tcp (ip, port) in
+      let tcp_flow = Eio.Net.connect ~sw net addr in
+      let host_domain = Domain_name.(host_exn (of_string_exn hostname)) in
+      let tls_flow = Tls_eio.client_of_flow client.tls_config ~host:host_domain tcp_flow in
+      let buf = Eio.Buf_read.of_flow ~max_size:max_body_size tls_flow in
+      Ok { flow = tls_flow; buf; last_used = Unix.gettimeofday () }
+  | Some _ -> Error (sprintf "Non-TCP address resolved for %s" hostname)
 
 (** Direct HTTPS GET 요청 - TCP 연결 + TLS + HTTP/1.1 *)
 let https_get_raw ~sw ~net ~client ~headers url =
@@ -650,12 +650,14 @@ let https_get_raw ~sw ~net ~client ~headers url =
         (match use_conn conn with
          | Ok res -> res
          | Error _ ->
-             let fresh = open_raw_connection ~sw ~net ~client ~hostname ~port in
+             let fresh = match open_raw_connection ~sw ~net ~client ~hostname ~port with
+               | Ok c -> c | Error msg -> raise (Connection_failed msg) in
              (match use_conn fresh with
               | Ok res -> res
               | Error exn -> raise exn))
     | None ->
-        let fresh = open_raw_connection ~sw ~net ~client ~hostname ~port in
+        let fresh = match open_raw_connection ~sw ~net ~client ~hostname ~port with
+          | Ok c -> c | Error msg -> raise (Connection_failed msg) in
         (match use_conn fresh with
          | Ok res -> res
          | Error exn -> raise exn)
@@ -701,12 +703,14 @@ let https_post_raw ~sw ~net ~client ~headers url body_content =
         (match use_conn conn with
          | Ok res -> res
          | Error _ ->
-             let fresh = open_raw_connection ~sw ~net ~client ~hostname ~port in
+             let fresh = match open_raw_connection ~sw ~net ~client ~hostname ~port with
+               | Ok c -> c | Error msg -> raise (Connection_failed msg) in
              (match use_conn fresh with
               | Ok res -> res
               | Error exn -> raise exn))
     | None ->
-        let fresh = open_raw_connection ~sw ~net ~client ~hostname ~port in
+        let fresh = match open_raw_connection ~sw ~net ~client ~hostname ~port with
+          | Ok c -> c | Error msg -> raise (Connection_failed msg) in
         (match use_conn fresh with
          | Ok res -> res
          | Error exn -> raise exn)

--- a/lib/figma_crawl.ml
+++ b/lib/figma_crawl.ml
@@ -369,19 +369,20 @@ let crawl_team ~token ~team_id ~neo4j_cfg
   on_progress (sprintf "🏢 Starting crawl for team: %s (%s)" team_name team_id);
   on_progress "─────────────────────────────────────────";
 
-  (* Neo4j 연결 테스트 *)
-  (match test_connection ~neo4j_cfg with
-   | Ok () -> on_progress "✅ Neo4j connection OK"
-   | Error err ->
-       on_progress (sprintf "❌ Neo4j connection failed: %s" err);
-       failwith err);
+  (* Neo4j 연결 테스트 — crawl cannot proceed without Neo4j *)
+  match test_connection ~neo4j_cfg with
+  | Error err ->
+      on_progress (sprintf "❌ Neo4j connection failed: %s" err);
+      Error err
+  | Ok () ->
+  on_progress "✅ Neo4j connection OK";
 
-  (* 팀 노드 생성 — fatal: crawl cannot proceed without team *)
-  (match create_figma_team ~neo4j_cfg ~team_id ~name:team_name with
-   | Ok _ -> ()
-   | Error msg ->
-       on_progress (sprintf "❌ create_figma_team(%s) failed: %s" team_id msg);
-       failwith (sprintf "Team creation failed: %s" msg));
+  (* 팀 노드 생성 — crawl cannot proceed without team *)
+  match create_figma_team ~neo4j_cfg ~team_id ~name:team_name with
+  | Error msg ->
+      on_progress (sprintf "❌ create_figma_team(%s) failed: %s" team_id msg);
+      Error (sprintf "Team creation failed: %s" msg)
+  | Ok _ ->
   progress.teams <- 1;
 
   (* 프로젝트 목록 가져오기 *)

--- a/lib/mcp_protocol_eio.ml
+++ b/lib/mcp_protocol_eio.ml
@@ -1576,6 +1576,9 @@ let template_handler ~sw:_ ~eio_ctx:_ _request reqd =
         Response.json (Yojson.Safe.to_string result) reqd
   )
 
+(** Codegen HTTP 오류 — Claude/Ollama fallback chain에서 사용 *)
+exception Codegen_http_error of int * string
+
 (** Plugin codegen handler - calls llm-mcp for code generation *)
 let plugin_codegen_handler ~sw ~eio_ctx _request reqd =
   Request.read_body_async reqd (fun body_str ->
@@ -1623,7 +1626,8 @@ let plugin_codegen_handler ~sw ~eio_ctx _request reqd =
           let uri = Uri.of_string ollama_url in
           let resp, resp_body = Cohttp_eio.Client.post cohttp ~sw ~headers ~body:req_body uri in
           let status_code = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
-          if status_code < 200 || status_code >= 300 then failwith "Ollama HTTP error";
+          if status_code < 200 || status_code >= 300 then
+            raise (Codegen_http_error (status_code, "Ollama"));
           let ollama_resp_str = Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(10 * 1024 * 1024) in
           let ollama_resp = Yojson.Safe.from_string ollama_resp_str in
           let gen_code = member "response" ollama_resp |> to_string_option |> Option.value ~default:"" in
@@ -1663,7 +1667,7 @@ let plugin_codegen_handler ~sw ~eio_ctx _request reqd =
               if status_code < 200 || status_code >= 300 then begin
                 let err_body = try Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:4096 with _ -> "" in
                 printf "[Codegen] Claude HTTP %d: %s\n%!" status_code err_body;
-                failwith (sprintf "Claude HTTP %d" status_code)
+                raise (Codegen_http_error (status_code, "Claude"))
               end;
               let claude_resp_str = Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(10 * 1024 * 1024) in
               let claude_resp = Yojson.Safe.from_string claude_resp_str in


### PR DESCRIPTION
## Summary
- `figma_api_eio.ml`: `open_raw_connection` returns `Result` instead of `failwith`; callers raise typed `Connection_failed` exception
- `figma_crawl.ml`: `crawl_team` uses nested `match` for early exits instead of `failwith`
- `mcp_protocol_eio.ml`: Codegen fallback chain uses typed `Codegen_http_error` instead of generic `failwith`

5 startup-fatal `failwith` calls intentionally kept (missing FIGMA_TOKEN, CA cert errors, no sockets).

## Test plan
- [x] `dune build` — zero warnings
- [x] `dune runtest` — 65 tests pass
- [x] Verified remaining `failwith` calls are all startup-fatal

🤖 Generated with [Claude Code](https://claude.com/claude-code)