### PR TITLE
test: coverage wave 4 — handler and mid-tier modules (57.79% → 62.38%)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -309,3 +309,28 @@
 (test
  (name test_mcp_tools_extra)
  (libraries figma_mcp alcotest yojson str unix))
+
+; Coverage Wave 4: mcp_helpers + figma_effects + server_metrics (remaining branches)
+(test
+ (name test_helpers_effects_w4)
+ (libraries figma_mcp alcotest yojson str unix eio_main httpun))
+
+; Coverage Wave 4: visual_verifier + semantic_verifier + figma_image_similarity (85%+ target)
+(test
+ (name test_verifiers_coverage_w4)
+ (libraries figma_mcp alcotest yojson str unix))
+
+; Coverage Wave 4: mcp_api_handlers.ml (uncovered handler branches — 78%+ target)
+(test
+ (name test_api_handlers_w4)
+ (libraries figma_mcp alcotest yojson str unix))
+
+; Coverage Wave 4: mcp_visual_handlers.ml (uncovered handler paths — 75%+ target)
+(test
+ (name test_visual_handlers_w4)
+ (libraries figma_mcp alcotest yojson str unix))
+
+; Coverage Wave 4: plugin handlers + features + bridge (60%+ / 80%+ / 45%+ targets)
+(test
+ (name test_plugin_w4)
+ (libraries figma_mcp alcotest yojson str unix))

--- a/test/test_api_handlers_w4.ml
+++ b/test/test_api_handlers_w4.ml
@@ -1,0 +1,1450 @@
+(** Coverage Wave 4: mcp_api_handlers.ml — exercise UNCOVERED handler branches.
+
+    Focus: optional params, format variations, error paths, download paths,
+    text_mode filtering, scoring logic, depth filtering, node_chunk trimming,
+    export_smart split/debug, image_fills download, post_comment node_id,
+    get_nodes fidelity conversion, node_summary truncation.
+
+    Uses the same Effect.Deep.try_with mock pattern as test_api_handlers_effects.ml
+    but with richer mock data to exercise deeper branches. *)
+
+open Figma_mcp [@@warning "-33"]
+
+(* Set FIGMA_TOKEN for resolve_token *)
+let () = Unix.putenv "FIGMA_TOKEN" "test-token-w4"
+
+(* ================================================================
+   Helpers
+   ================================================================ *)
+
+let args_of pairs =
+  `Assoc pairs
+
+let check_ok label = function
+  | Ok _ -> ()
+  | Error msg -> Alcotest.fail (Printf.sprintf "%s: expected Ok, got Error %s" label msg)
+
+let check_error label = function
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail (Printf.sprintf "%s: expected Error, got Ok" label)
+
+let str_contains haystack needle =
+  try
+    let _ = Str.search_forward (Str.regexp_string needle) haystack 0 in true
+  with Not_found -> false
+
+(* ================================================================
+   Rich mock node data for deep branch coverage
+   ================================================================ *)
+
+(* A FRAME node with children of various types for select_nodes scoring *)
+let rich_frame_node =
+  `Assoc [
+    ("id", `String "1:1");
+    ("name", `String "MainFrame");
+    ("type", `String "FRAME");
+    ("visible", `Bool true);
+    ("opacity", `Float 1.0);
+    ("absoluteBoundingBox", `Assoc [
+      ("x", `Float 0.0); ("y", `Float 0.0);
+      ("width", `Float 800.0); ("height", `Float 600.0);
+    ]);
+    ("children", `List [
+      (* Text node — scores text:+2, area OK *)
+      `Assoc [
+        ("id", `String "2:1");
+        ("name", `String "Title");
+        ("type", `String "TEXT");
+        ("characters", `String "Hello World");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 10.0); ("y", `Float 10.0);
+          ("width", `Float 200.0); ("height", `Float 50.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* COMPONENT_SET — scores component:+1 *)
+      `Assoc [
+        ("id", `String "2:2");
+        ("name", `String "ButtonGroup");
+        ("type", `String "COMPONENT_SET");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 10.0); ("y", `Float 80.0);
+          ("width", `Float 300.0); ("height", `Float 100.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* Small invisible node — excluded invisible *)
+      `Assoc [
+        ("id", `String "2:3");
+        ("name", `String "Hidden");
+        ("type", `String "RECTANGLE");
+        ("visible", `Bool false);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 5.0); ("height", `Float 5.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* RECTANGLE with image fill — scores image_fill:+2 *)
+      `Assoc [
+        ("id", `String "2:4");
+        ("name", `String "Hero Image");
+        ("type", `String "RECTANGLE");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("fills", `List [
+          `Assoc [("type", `String "IMAGE"); ("imageRef", `String "img:abc")]
+        ]);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 200.0);
+          ("width", `Float 400.0); ("height", `Float 300.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* FRAME with auto-layout — scores auto_layout:+1.5 *)
+      `Assoc [
+        ("id", `String "2:5");
+        ("name", `String "AutoRow");
+        ("type", `String "FRAME");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("layoutMode", `String "HORIZONTAL");
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 500.0);
+          ("width", `Float 600.0); ("height", `Float 80.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* Tiny node — small_penalty area < 64 *)
+      `Assoc [
+        ("id", `String "2:6");
+        ("name", `String "Dot");
+        ("type", `String "ELLIPSE");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 4.0); ("height", `Float 4.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* Duplicate of AutoRow — duplicate:-1 penalty *)
+      `Assoc [
+        ("id", `String "2:7");
+        ("name", `String "AutoRow");
+        ("type", `String "FRAME");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("layoutMode", `String "HORIZONTAL");
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 580.0);
+          ("width", `Float 600.0); ("height", `Float 80.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* "as-is" named node — as_is:-0.5 penalty *)
+      `Assoc [
+        ("id", `String "2:8");
+        ("name", `String "as-is placeholder");
+        ("type", `String "RECTANGLE");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 100.0); ("height", `Float 100.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* Mask hint node *)
+      `Assoc [
+        ("id", `String "2:9");
+        ("name", `String "ClipMask");
+        ("type", `String "RECTANGLE");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("isMask", `Bool true);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 200.0); ("height", `Float 200.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* Zero opacity — invisible *)
+      `Assoc [
+        ("id", `String "2:10");
+        ("name", `String "Phantom");
+        ("type", `String "RECTANGLE");
+        ("visible", `Bool true);
+        ("opacity", `Float 0.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 100.0); ("height", `Float 100.0);
+        ]);
+        ("children", `List []);
+      ];
+      (* Note text — should be captured in notes and excluded *)
+      `Assoc [
+        ("id", `String "2:11");
+        ("name", `String "TODO: fix spacing");
+        ("type", `String "TEXT");
+        ("characters", `String "TODO: fix spacing issue here");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 200.0); ("height", `Float 30.0);
+        ]);
+        ("children", `List []);
+      ];
+    ]);
+  ]
+
+(* Document wrapper for the rich frame *)
+let rich_document =
+  `Assoc [
+    ("document", `Assoc [
+      ("id", `String "0:0");
+      ("name", `String "Doc");
+      ("type", `String "DOCUMENT");
+      ("children", `List [
+        `Assoc [
+          ("id", `String "1:0");
+          ("name", `String "Page 1");
+          ("type", `String "CANVAS");
+          ("children", `List [rich_frame_node])
+        ]
+      ])
+    ])
+  ]
+
+(* Node wrapper for rich frame *)
+let rich_nodes_response node_id =
+  `Assoc [("nodes", `Assoc [
+    (node_id, `Assoc [("document", rich_frame_node)])
+  ])]
+
+(* Node with many children for large node testing *)
+let make_many_children n =
+  List.init n (fun i ->
+    `Assoc [
+      ("id", `String (Printf.sprintf "c:%d" i));
+      ("name", `String (Printf.sprintf "Child%d" i));
+      ("type", `String "RECTANGLE");
+      ("visible", `Bool true);
+      ("opacity", `Float 1.0);
+      ("absoluteBoundingBox", `Assoc [
+        ("x", `Float (float_of_int (i * 10)));
+        ("y", `Float 0.0);
+        ("width", `Float 50.0); ("height", `Float 50.0);
+      ]);
+      ("children", `List []);
+    ])
+
+let large_node_response node_id n =
+  `Assoc [("nodes", `Assoc [
+    (node_id, `Assoc [
+      ("document", `Assoc [
+        ("id", `String node_id);
+        ("name", `String "LargeFrame");
+        ("type", `String "FRAME");
+        ("visible", `Bool true);
+        ("opacity", `Float 1.0);
+        ("absoluteBoundingBox", `Assoc [
+          ("x", `Float 0.0); ("y", `Float 0.0);
+          ("width", `Float 1000.0); ("height", `Float 1000.0);
+        ]);
+        ("children", `List (make_many_children n));
+      ])
+    ])
+  ])]
+
+(* ================================================================
+   Mock effects with configurable responses
+   ================================================================ *)
+
+(* Default mock that returns rich data *)
+let with_mock_effects ?(get_file_result=Ok rich_document)
+                       ?(get_nodes_fn=fun _node_ids -> Ok (rich_nodes_response "1:1"))
+                       ?(get_images_fn=fun node_ids ->
+                          let img_entries = List.map (fun nid ->
+                            (nid, `String "https://example.com/img.png")
+                          ) node_ids in
+                          Ok (`Assoc [("images", `Assoc img_entries)]))
+                       ?(get_file_images_result=Ok (`Assoc [("images", `Assoc [
+                          ("img:abc", `String "https://example.com/fill.png");
+                          ("img:def", `String "not-a-url");
+                       ])]))
+                       ?(get_file_meta_result=Ok (`Assoc [
+                          ("components", `Assoc []);
+                          ("componentSets", `Assoc []);
+                          ("styles", `Assoc [])
+                        ]))
+                       ?(download_url_result=Ok "/tmp/downloaded.png")
+                       ?(get_variables_result=Ok (`Assoc [("variables", `Assoc [])]))
+                       ?(get_file_styles_result=Ok (`Assoc [("data", `List [])]))
+                       f =
+  Effect.Deep.try_with f ()
+    { effc = fun (type a) (eff : a Effect.t) ->
+        match eff with
+        | Figma_effects.Figma_get_file _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k get_file_result)
+
+        | Figma_effects.Figma_get_nodes { node_ids; _ } ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (get_nodes_fn node_ids))
+
+        | Figma_effects.Figma_get_images { node_ids; _ } ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (get_images_fn node_ids))
+
+        | Figma_effects.Figma_get_file_images _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k get_file_images_result)
+
+        | Figma_effects.Figma_get_file_meta _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k get_file_meta_result)
+
+        | Figma_effects.Figma_download_url _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k download_url_result)
+
+        | Figma_effects.Figma_get_variables _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k get_variables_result)
+
+        | Figma_effects.Figma_get_file_components _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_team_components _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_file_component_sets _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_team_component_sets _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_file_styles _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k get_file_styles_result)
+        | Figma_effects.Figma_get_team_styles _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_component _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_component_set _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_style _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_file_versions _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_get_file_comments _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("data", `List [])])))
+        | Figma_effects.Figma_post_file_comment _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("id", `String "comment-1")])))
+        | Figma_effects.Figma_create_webhook _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("id", `String "webhook-1")])))
+        | Figma_effects.Figma_get_dev_resources _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("dev_resources", `List [])])))
+        | Figma_effects.Figma_add_dev_resource _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k (Ok (`Assoc [("id", `String "dev-res-1")])))
+        | Figma_effects.Log_debug _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k ())
+        | Figma_effects.Log_info _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k ())
+        | Figma_effects.Log_error _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k ())
+        | Figma_effects.Eio_sleep _ ->
+            Some (fun (k : (a, _) Effect.Deep.continuation) ->
+              Effect.Deep.continue k ())
+        | _ -> None }
+
+
+(* ================================================================
+   Tests: handle_get_file branches
+   ================================================================ *)
+
+let test_get_file_format_raw () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1"); ("format", `String "raw")] in
+    check_ok "get_file raw" (Mcp_api_handlers.handle_get_file args))
+
+let test_get_file_with_optional_params () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("depth", `Int 2);
+      ("geometry", `String "paths");
+      ("plugin_data", `String "shared");
+      ("version", `String "v123");
+    ] in
+    check_ok "get_file with opts" (Mcp_api_handlers.handle_get_file args))
+
+let test_get_file_document_none () =
+  (* Return file without "document" key -> falls back to full JSON *)
+  with_mock_effects
+    ~get_file_result:(Ok (`Assoc [("name", `String "NoDoc")]))
+    (fun () ->
+      let args = args_of [("file_key", `String "f1")] in
+      check_ok "get_file no document" (Mcp_api_handlers.handle_get_file args))
+
+let test_get_file_api_error () =
+  with_mock_effects
+    ~get_file_result:(Error "API timeout")
+    (fun () ->
+      let args = args_of [("file_key", `String "f1")] in
+      check_error "get_file api error" (Mcp_api_handlers.handle_get_file args))
+
+(* ================================================================
+   Tests: handle_get_file_meta branches
+   ================================================================ *)
+
+let test_get_file_meta_with_version () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("version", `String "v456");
+    ] in
+    check_ok "get_file_meta with version" (Mcp_api_handlers.handle_get_file_meta args))
+
+(* ================================================================
+   Tests: handle_get_node branches
+   ================================================================ *)
+
+let test_get_node_format_raw () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("format", `String "raw");
+    ] in
+    check_ok "get_node raw" (Mcp_api_handlers.handle_get_node args))
+
+let test_get_node_with_opts () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("depth", `Int 3);
+      ("geometry", `String "paths");
+      ("plugin_data", `String "shared");
+      ("version", `String "v789");
+    ] in
+    check_ok "get_node with opts" (Mcp_api_handlers.handle_get_node args))
+
+let test_get_node_not_found () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [("other:id", `Assoc [("document", `Null)])])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+      ] in
+      check_error "get_node not found" (Mcp_api_handlers.handle_get_node args))
+
+let test_get_node_data_none () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      (* node entry exists but has no "document" field *)
+      Ok (`Assoc [("nodes", `Assoc [("1:1", `Assoc [("other", `String "val")])])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1-1");
+      ] in
+      (* node_data is None because document key is missing *)
+      check_error "get_node data none" (Mcp_api_handlers.handle_get_node args))
+
+(* ================================================================
+   Tests: handle_get_node_bundle branches
+   ================================================================ *)
+
+let test_bundle_include_meta_false () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("include_meta", `Bool false);
+      ("include_variables", `Bool false);
+      ("include_image_fills", `Bool false);
+      ("include_plugin", `Bool false);
+      ("include_raw", `Bool false);
+    ] in
+    check_ok "bundle meta false" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_download_true () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("download", `Bool true);
+      ("include_meta", `Bool false);
+      ("include_variables", `Bool false);
+      ("include_image_fills", `Bool true);
+      ("include_plugin", `Bool false);
+    ] in
+    check_ok "bundle download" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_node_not_found () =
+  Figma_cache.invalidate ();
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-notfound");
+        ("node_id", `String "99:99");
+      ] in
+      check_error "bundle node not found" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_nodes_missing_field () =
+  Figma_cache.invalidate ();
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("other", `Null)]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-nomissing");
+        ("node_id", `String "88:88");
+      ] in
+      check_error "bundle nodes missing" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_document_null () =
+  Figma_cache.invalidate ();
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      (* document key absent → handler's member returns None → Error path *)
+      Ok (`Assoc [("nodes", `Assoc [("77:77", `Assoc [("components", `Assoc [])])])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-docnull");
+        ("node_id", `String "77:77");
+      ] in
+      check_error "bundle doc null" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_api_error () =
+  Figma_cache.invalidate ();
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids -> Error "Rate limited")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-apierr");
+        ("node_id", `String "66:66");
+      ] in
+      check_error "bundle api error" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_image_error () =
+  with_mock_effects
+    ~get_images_fn:(fun _ids -> Error "Image service down")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("include_meta", `Bool false);
+        ("include_variables", `Bool false);
+        ("include_image_fills", `Bool false);
+        ("include_plugin", `Bool false);
+      ] in
+      check_ok "bundle image error" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_download_no_url () =
+  with_mock_effects
+    ~get_images_fn:(fun _ids ->
+      Ok (`Assoc [("images", `Assoc [("1:1", `Null)])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("download", `Bool true);
+        ("include_meta", `Bool false);
+        ("include_variables", `Bool false);
+        ("include_image_fills", `Bool false);
+        ("include_plugin", `Bool false);
+      ] in
+      check_ok "bundle download no url" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_format_raw () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("format", `String "raw");
+      ("include_meta", `Bool false);
+      ("include_variables", `Bool false);
+      ("include_image_fills", `Bool false);
+      ("include_plugin", `Bool false);
+    ] in
+    check_ok "bundle format raw" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_nodes_unexpected_format () =
+  Figma_cache.invalidate ();
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `String "unexpected")]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-unexpfmt");
+        ("node_id", `String "55:55");
+      ] in
+      check_error "bundle unexpected format" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_meta_error () =
+  with_mock_effects
+    ~get_file_meta_result:(Error "Meta service down")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("include_meta", `Bool true);
+        ("include_variables", `Bool false);
+        ("include_image_fills", `Bool false);
+        ("include_plugin", `Bool false);
+      ] in
+      check_ok "bundle meta error" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_variables_error () =
+  with_mock_effects
+    ~get_variables_result:(Error "Variables API error")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("include_meta", `Bool false);
+        ("include_variables", `Bool true);
+        ("include_image_fills", `Bool false);
+        ("include_plugin", `Bool false);
+      ] in
+      check_ok "bundle var error" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_file_images_error () =
+  with_mock_effects
+    ~get_file_images_result:(Error "File images error")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("include_meta", `Bool false);
+        ("include_variables", `Bool false);
+        ("include_image_fills", `Bool true);
+        ("include_plugin", `Bool false);
+      ] in
+      check_ok "bundle fill error" (Mcp_api_handlers.handle_get_node_bundle args))
+
+let test_bundle_download_error () =
+  with_mock_effects
+    ~download_url_result:(Error "Disk full")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("download", `Bool true);
+        ("include_meta", `Bool false);
+        ("include_variables", `Bool false);
+        ("include_image_fills", `Bool false);
+        ("include_plugin", `Bool false);
+      ] in
+      check_ok "bundle dl error" (Mcp_api_handlers.handle_get_node_bundle args))
+
+(* ================================================================
+   Tests: handle_get_node_summary branches
+   ================================================================ *)
+
+let test_summary_with_children () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+    ] in
+    check_ok "summary with children" (Mcp_api_handlers.handle_get_node_summary args))
+
+let test_summary_truncated () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("max_children", `Int 2);
+    ] in
+    let result = Mcp_api_handlers.handle_get_node_summary args in
+    check_ok "summary truncated" result;
+    match result with
+    | Ok json ->
+        let s = Yojson.Safe.to_string json in
+        Alcotest.(check bool) "truncated true" true (str_contains s "true")
+    | Error _ -> ())
+
+let test_summary_node_not_found () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+      ] in
+      check_error "summary not found" (Mcp_api_handlers.handle_get_node_summary args))
+
+let test_summary_api_error () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids -> Error "timeout")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+      ] in
+      check_error "summary api error" (Mcp_api_handlers.handle_get_node_summary args))
+
+let test_summary_doc_null () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [("1:1", `Assoc [("document", `Null)])])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1-1");
+      ] in
+      check_error "summary doc null" (Mcp_api_handlers.handle_get_node_summary args))
+
+(* ================================================================
+   Tests: handle_select_nodes branches
+   ================================================================ *)
+
+let test_select_text_mode_exclude () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("text_mode", `String "exclude");
+    ] in
+    check_ok "select text_mode exclude" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_text_mode_only () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("text_mode", `String "only");
+    ] in
+    check_ok "select text_mode only" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_text_mode_invalid () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("text_mode", `String "bogus");
+    ] in
+    let result = Mcp_api_handlers.handle_select_nodes args in
+    check_ok "select invalid text_mode" result;
+    match result with
+    | Ok json ->
+        let s = Yojson.Safe.to_string json in
+        Alcotest.(check bool) "warning present" true
+          (str_contains s "Invalid text_mode")
+    | Error _ -> ())
+
+let test_select_layout_only () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("layout_only", `Bool true);
+    ] in
+    check_ok "select layout_only" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_auto_layout_only () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("auto_layout_only", `Bool true);
+    ] in
+    check_ok "select auto_layout_only" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_high_threshold_fallback () =
+  (* Very high threshold -> no nodes pass -> fallback_top_scores mode *)
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("score_threshold", `Float 999.0);
+    ] in
+    let result = Mcp_api_handlers.handle_select_nodes args in
+    check_ok "select fallback" result;
+    match result with
+    | Ok json ->
+        let s = Yojson.Safe.to_string json in
+        Alcotest.(check bool) "fallback mode" true
+          (str_contains s "fallback_top_scores")
+    | Error _ -> ())
+
+let test_select_preview_false () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("preview", `Bool false);
+    ] in
+    check_ok "select no preview" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_preview_error () =
+  with_mock_effects
+    ~get_images_fn:(fun _ids -> Error "Preview error")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("preview", `Bool true);
+      ] in
+      check_ok "select preview error" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_summary_depth_clamped () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("summary_depth", `Int 100);
+    ] in
+    let result = Mcp_api_handlers.handle_select_nodes args in
+    check_ok "select depth clamped" result;
+    match result with
+    | Ok json ->
+        let s = Yojson.Safe.to_string json in
+        Alcotest.(check bool) "depth clamped warning" true
+          (str_contains s "summary_depth clamped")
+    | Error _ -> ())
+
+let test_select_preview_scale_clamped () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("preview_scale", `Float 10.0);
+    ] in
+    let result = Mcp_api_handlers.handle_select_nodes args in
+    check_ok "select scale clamped" result;
+    match result with
+    | Ok json ->
+        let s = Yojson.Safe.to_string json in
+        Alcotest.(check bool) "scale warning" true
+          (str_contains s "preview_scale clamped")
+    | Error _ -> ())
+
+let test_select_negative_summary_depth () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("summary_depth", `Int (-1));
+    ] in
+    check_ok "select negative depth" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_node_null () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [("1:1", `Null)])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1-1");
+      ] in
+      check_error "select node null" (Mcp_api_handlers.handle_select_nodes args))
+
+let test_select_doc_null () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [("1:1", `Assoc [("document", `Null)])])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1-1");
+      ] in
+      check_error "select doc null" (Mcp_api_handlers.handle_select_nodes args))
+
+(* ================================================================
+   Tests: handle_get_node_chunk branches
+   ================================================================ *)
+
+let test_chunk_depth_end_lt_start () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("depth_start", `Int 5);
+      ("depth_end", `Int 2);
+    ] in
+    check_error "chunk depth error" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_with_max_children () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("max_children", `Int 3);
+    ] in
+    check_ok "chunk max_children" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_auto_trim () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("auto_trim_children", `Bool true);
+      ("auto_trim_limit", `Int 5);
+    ] in
+    check_ok "chunk auto_trim" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_include_styles () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("include_styles", `Bool true);
+    ] in
+    check_ok "chunk styles" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_error_on_large () =
+  Figma_cache.invalidate ();
+  (* Use mock that returns a node with > 500 children *)
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids -> Ok (large_node_response "44:44" 600))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-chunkerr");
+        ("node_id", `String "44:44");
+        ("error_on_large", `Bool true);
+        ("warn_threshold", `Int 500);
+      ] in
+      check_error "chunk error large" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_warn_large () =
+  Figma_cache.invalidate ();
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids -> Ok (large_node_response "43:43" 600))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f-chunkwarn");
+        ("node_id", `String "43:43");
+        ("warn_large", `Bool true);
+        ("warn_threshold", `Int 500);
+      ] in
+      let result = Mcp_api_handlers.handle_get_node_chunk args in
+      (* Returns Ok even with large node when error_on_large=false *)
+      check_ok "chunk warn large" result;
+      (* Warning may be in saved file if result exceeds max_inline_size.
+         Just verify the handler completed successfully with Ok. *)
+      match result with
+      | Ok json ->
+          let s = Yojson.Safe.to_string json in
+          (* Check either inline warning or large_result indicator *)
+          let has_warning = str_contains s "Large node" in
+          let has_large_result = str_contains s "large_result" in
+          Alcotest.(check bool) "warning or large_result" true (has_warning || has_large_result)
+      | Error _ -> ())
+
+let test_chunk_format_raw () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("format", `String "raw");
+    ] in
+    check_ok "chunk raw" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_node_not_found () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [("1:1", `Null)])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1-1");
+      ] in
+      check_error "chunk not found" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_doc_null () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids ->
+      Ok (`Assoc [("nodes", `Assoc [("1:1", `Assoc [("document", `Null)])])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1-1");
+      ] in
+      check_error "chunk doc null" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_depth_range () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_id", `String "1:1");
+      ("depth_start", `Int 1);
+      ("depth_end", `Int 1);
+    ] in
+    check_ok "chunk depth range" (Mcp_api_handlers.handle_get_node_chunk args))
+
+let test_chunk_styles_error () =
+  with_mock_effects
+    ~get_file_styles_result:(Error "Styles unavailable")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("include_styles", `Bool true);
+      ] in
+      check_ok "chunk styles error" (Mcp_api_handlers.handle_get_node_chunk args))
+
+(* ================================================================
+   Tests: handle_export_image branches
+   ================================================================ *)
+
+let test_export_image_download () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_ids", `String "1:1,2:1");
+      ("download", `Bool true);
+    ] in
+    check_ok "export download" (Mcp_api_handlers.handle_export_image args))
+
+let test_export_image_download_error () =
+  with_mock_effects
+    ~download_url_result:(Error "Disk error")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_ids", `String "1:1");
+        ("download", `Bool true);
+      ] in
+      check_ok "export dl error" (Mcp_api_handlers.handle_export_image args))
+
+let test_export_image_multi_progress () =
+  (* 3+ images triggers progress *)
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_ids", `String "1:1,2:1,3:1");
+      ("download", `Bool true);
+    ] in
+    check_ok "export multi progress" (Mcp_api_handlers.handle_export_image args))
+
+let test_export_image_no_images () =
+  with_mock_effects
+    ~get_images_fn:(fun _ids -> Ok (`Assoc [("images", `Null)]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_ids", `String "1:1");
+      ] in
+      check_ok "export no images" (Mcp_api_handlers.handle_export_image args))
+
+(* ================================================================
+   Tests: handle_export_smart branches
+   ================================================================ *)
+
+let test_export_smart_basic () =
+  with_mock_effects
+    ~get_nodes_fn:(fun ids ->
+      let nid = List.hd ids in
+      Ok (`Assoc [("nodes", `Assoc [
+        (nid, `Assoc [
+          ("document", `Assoc [
+            ("id", `String nid);
+            ("name", `String "SmartFrame");
+            ("type", `String "FRAME");
+            ("absoluteBoundingBox", `Assoc [
+              ("x", `Float 0.0); ("y", `Float 0.0);
+              ("width", `Float 200.0); ("height", `Float 200.0);
+            ]);
+            ("children", `List []);
+          ])
+        ])
+      ])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+      ] in
+      check_ok "export smart basic" (Mcp_api_handlers.handle_export_smart args))
+
+let test_export_smart_download () =
+  with_mock_effects
+    ~get_nodes_fn:(fun ids ->
+      let nid = List.hd ids in
+      Ok (`Assoc [("nodes", `Assoc [
+        (nid, `Assoc [
+          ("document", `Assoc [
+            ("id", `String nid);
+            ("name", `String "SmartFrame");
+            ("type", `String "FRAME");
+            ("absoluteBoundingBox", `Assoc [
+              ("x", `Float 0.0); ("y", `Float 0.0);
+              ("width", `Float 200.0); ("height", `Float 200.0);
+            ]);
+            ("children", `List []);
+          ])
+        ])
+      ])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("download", `Bool true);
+      ] in
+      check_ok "export smart download" (Mcp_api_handlers.handle_export_smart args))
+
+let test_export_smart_debug () =
+  with_mock_effects
+    ~get_nodes_fn:(fun ids ->
+      let nid = List.hd ids in
+      Ok (`Assoc [("nodes", `Assoc [
+        (nid, `Assoc [
+          ("document", `Assoc [
+            ("id", `String nid);
+            ("name", `String "SmartFrame");
+            ("type", `String "FRAME");
+            ("absoluteBoundingBox", `Assoc [
+              ("x", `Float 0.0); ("y", `Float 0.0);
+              ("width", `Float 200.0); ("height", `Float 200.0);
+            ]);
+            ("children", `List []);
+          ])
+        ])
+      ])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+        ("debug", `Bool true);
+      ] in
+      check_ok "export smart debug" (Mcp_api_handlers.handle_export_smart args))
+
+let test_export_smart_large_auto_scale () =
+  (* Large node that triggers auto_scale *)
+  with_mock_effects
+    ~get_nodes_fn:(fun ids ->
+      let nid = List.hd ids in
+      Ok (`Assoc [("nodes", `Assoc [
+        (nid, `Assoc [
+          ("document", `Assoc [
+            ("id", `String nid);
+            ("name", `String "HugeFrame");
+            ("type", `String "FRAME");
+            ("absoluteBoundingBox", `Assoc [
+              ("x", `Float 0.0); ("y", `Float 0.0);
+              ("width", `Float 10000.0); ("height", `Float 10000.0);
+            ]);
+            ("children", `List []);
+          ])
+        ])
+      ])]))
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_id", `String "1:1");
+      ] in
+      check_ok "export smart auto_scale" (Mcp_api_handlers.handle_export_smart args))
+
+(* ================================================================
+   Tests: handle_get_image_fills branches
+   ================================================================ *)
+
+let test_image_fills_download () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("download", `Bool true);
+    ] in
+    check_ok "image_fills download" (Mcp_api_handlers.handle_get_image_fills args))
+
+let test_image_fills_no_download () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "image_fills no download" (Mcp_api_handlers.handle_get_image_fills args))
+
+let test_image_fills_api_error () =
+  with_mock_effects
+    ~get_file_images_result:(Error "Fill error")
+    (fun () ->
+      let args = args_of [("file_key", `String "f1")] in
+      check_error "image_fills error" (Mcp_api_handlers.handle_get_image_fills args))
+
+(* ================================================================
+   Tests: handle_get_nodes branches
+   ================================================================ *)
+
+let test_get_nodes_format_fidelity () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_ids", `String "1:1");
+      ("format", `String "fidelity");
+    ] in
+    check_ok "get_nodes fidelity" (Mcp_api_handlers.handle_get_nodes args))
+
+let test_get_nodes_format_raw () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_ids", `String "1:1");
+      ("format", `String "raw");
+    ] in
+    check_ok "get_nodes raw" (Mcp_api_handlers.handle_get_nodes args))
+
+let test_get_nodes_api_error () =
+  with_mock_effects
+    ~get_nodes_fn:(fun _ids -> Error "API error")
+    (fun () ->
+      let args = args_of [
+        ("file_key", `String "f1");
+        ("node_ids", `String "1:1");
+      ] in
+      check_error "get_nodes error" (Mcp_api_handlers.handle_get_nodes args))
+
+let test_get_nodes_with_opts () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("node_ids", `String "1:1,2:1");
+      ("depth", `Int 2);
+      ("geometry", `String "paths");
+      ("plugin_data", `String "shared");
+      ("version", `String "v1");
+    ] in
+    check_ok "get_nodes with opts" (Mcp_api_handlers.handle_get_nodes args))
+
+(* ================================================================
+   Tests: handle_post_comment branches
+   ================================================================ *)
+
+let test_post_comment_with_node_id () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("message", `String "Nice work");
+      ("x", `Float 10.0);
+      ("y", `Float 20.0);
+      ("node_id", `String "1:1");
+    ] in
+    check_ok "post_comment with node_id" (Mcp_api_handlers.handle_post_comment args))
+
+let test_post_comment_no_node_id () =
+  with_mock_effects (fun () ->
+    let args = args_of [
+      ("file_key", `String "f1");
+      ("message", `String "General comment");
+      ("x", `Float 10.0);
+      ("y", `Float 20.0);
+    ] in
+    check_ok "post_comment no node_id" (Mcp_api_handlers.handle_post_comment args))
+
+(* ================================================================
+   Tests: handle_list_screens
+   ================================================================ *)
+
+let test_list_screens_ok () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "list_screens ok" (Mcp_api_handlers.handle_list_screens args))
+
+let test_list_screens_error () =
+  with_mock_effects
+    ~get_file_result:(Error "File not found")
+    (fun () ->
+      let args = args_of [("file_key", `String "f1")] in
+      check_error "list_screens error" (Mcp_api_handlers.handle_list_screens args))
+
+(* ================================================================
+   Tests: passthrough handlers (components, styles)
+   ================================================================ *)
+
+let test_get_file_components () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "file_components" (Mcp_api_handlers.handle_get_file_components args))
+
+let test_get_file_component_sets () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "file_component_sets" (Mcp_api_handlers.handle_get_file_component_sets args))
+
+let test_get_file_styles () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "file_styles" (Mcp_api_handlers.handle_get_file_styles args))
+
+let test_get_component () =
+  with_mock_effects (fun () ->
+    let args = args_of [("component_key", `String "comp1")] in
+    check_ok "component" (Mcp_api_handlers.handle_get_component args))
+
+let test_get_component_set () =
+  with_mock_effects (fun () ->
+    let args = args_of [("component_set_key", `String "cs1")] in
+    check_ok "component_set" (Mcp_api_handlers.handle_get_component_set args))
+
+let test_get_team_components () =
+  with_mock_effects (fun () ->
+    let args = args_of [("team_id", `String "t1")] in
+    check_ok "team_components" (Mcp_api_handlers.handle_get_team_components args))
+
+let test_get_team_component_sets () =
+  with_mock_effects (fun () ->
+    let args = args_of [("team_id", `String "t1")] in
+    check_ok "team_component_sets" (Mcp_api_handlers.handle_get_team_component_sets args))
+
+let test_get_team_styles () =
+  with_mock_effects (fun () ->
+    let args = args_of [("team_id", `String "t1")] in
+    check_ok "team_styles" (Mcp_api_handlers.handle_get_team_styles args))
+
+(* ================================================================
+   Tests: handle_get_file_versions / handle_get_file_comments
+   ================================================================ *)
+
+let test_get_file_versions () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "file_versions" (Mcp_api_handlers.handle_get_file_versions args))
+
+let test_get_file_comments () =
+  with_mock_effects (fun () ->
+    let args = args_of [("file_key", `String "f1")] in
+    check_ok "file_comments" (Mcp_api_handlers.handle_get_file_comments args))
+
+
+(* ================================================================
+   Test runner
+   ================================================================ *)
+
+let () =
+  Alcotest.run "mcp_api_handlers_w4" [
+    ("get_file", [
+      Alcotest.test_case "format raw" `Quick test_get_file_format_raw;
+      Alcotest.test_case "optional params" `Quick test_get_file_with_optional_params;
+      Alcotest.test_case "document none" `Quick test_get_file_document_none;
+      Alcotest.test_case "api error" `Quick test_get_file_api_error;
+    ]);
+    ("get_file_meta", [
+      Alcotest.test_case "with version" `Quick test_get_file_meta_with_version;
+    ]);
+    ("get_node", [
+      Alcotest.test_case "format raw" `Quick test_get_node_format_raw;
+      Alcotest.test_case "with opts" `Quick test_get_node_with_opts;
+      Alcotest.test_case "not found" `Quick test_get_node_not_found;
+      Alcotest.test_case "data none" `Quick test_get_node_data_none;
+    ]);
+    ("get_node_bundle", [
+      Alcotest.test_case "meta false" `Quick test_bundle_include_meta_false;
+      Alcotest.test_case "download true" `Quick test_bundle_download_true;
+      Alcotest.test_case "node not found" `Quick test_bundle_node_not_found;
+      Alcotest.test_case "nodes missing field" `Quick test_bundle_nodes_missing_field;
+      Alcotest.test_case "document null" `Quick test_bundle_document_null;
+      Alcotest.test_case "api error" `Quick test_bundle_api_error;
+      Alcotest.test_case "image error" `Quick test_bundle_image_error;
+      Alcotest.test_case "download no url" `Quick test_bundle_download_no_url;
+      Alcotest.test_case "format raw" `Quick test_bundle_format_raw;
+      Alcotest.test_case "unexpected format" `Quick test_bundle_nodes_unexpected_format;
+      Alcotest.test_case "meta error" `Quick test_bundle_meta_error;
+      Alcotest.test_case "variables error" `Quick test_bundle_variables_error;
+      Alcotest.test_case "file images error" `Quick test_bundle_file_images_error;
+      Alcotest.test_case "download error" `Quick test_bundle_download_error;
+    ]);
+    ("get_node_summary", [
+      Alcotest.test_case "with children" `Quick test_summary_with_children;
+      Alcotest.test_case "truncated" `Quick test_summary_truncated;
+      Alcotest.test_case "not found" `Quick test_summary_node_not_found;
+      Alcotest.test_case "api error" `Quick test_summary_api_error;
+      Alcotest.test_case "doc null" `Quick test_summary_doc_null;
+    ]);
+    ("select_nodes", [
+      Alcotest.test_case "text_mode exclude" `Quick test_select_text_mode_exclude;
+      Alcotest.test_case "text_mode only" `Quick test_select_text_mode_only;
+      Alcotest.test_case "text_mode invalid" `Quick test_select_text_mode_invalid;
+      Alcotest.test_case "layout_only" `Quick test_select_layout_only;
+      Alcotest.test_case "auto_layout_only" `Quick test_select_auto_layout_only;
+      Alcotest.test_case "high threshold fallback" `Quick test_select_high_threshold_fallback;
+      Alcotest.test_case "preview false" `Quick test_select_preview_false;
+      Alcotest.test_case "preview error" `Quick test_select_preview_error;
+      Alcotest.test_case "summary_depth clamped" `Quick test_select_summary_depth_clamped;
+      Alcotest.test_case "preview_scale clamped" `Quick test_select_preview_scale_clamped;
+      Alcotest.test_case "negative summary_depth" `Quick test_select_negative_summary_depth;
+      Alcotest.test_case "node null" `Quick test_select_node_null;
+      Alcotest.test_case "doc null" `Quick test_select_doc_null;
+    ]);
+    ("get_node_chunk", [
+      Alcotest.test_case "depth_end < start" `Quick test_chunk_depth_end_lt_start;
+      Alcotest.test_case "max_children" `Quick test_chunk_with_max_children;
+      Alcotest.test_case "auto_trim" `Quick test_chunk_auto_trim;
+      Alcotest.test_case "include_styles" `Quick test_chunk_include_styles;
+      Alcotest.test_case "error_on_large" `Quick test_chunk_error_on_large;
+      Alcotest.test_case "warn_large" `Quick test_chunk_warn_large;
+      Alcotest.test_case "format raw" `Quick test_chunk_format_raw;
+      Alcotest.test_case "not found" `Quick test_chunk_node_not_found;
+      Alcotest.test_case "doc null" `Quick test_chunk_doc_null;
+      Alcotest.test_case "depth range" `Quick test_chunk_depth_range;
+      Alcotest.test_case "styles error" `Quick test_chunk_styles_error;
+    ]);
+    ("export_image", [
+      Alcotest.test_case "download" `Quick test_export_image_download;
+      Alcotest.test_case "download error" `Quick test_export_image_download_error;
+      Alcotest.test_case "multi progress" `Quick test_export_image_multi_progress;
+      Alcotest.test_case "no images" `Quick test_export_image_no_images;
+    ]);
+    ("export_smart", [
+      Alcotest.test_case "basic" `Quick test_export_smart_basic;
+      Alcotest.test_case "download" `Quick test_export_smart_download;
+      Alcotest.test_case "debug" `Quick test_export_smart_debug;
+      Alcotest.test_case "auto_scale" `Quick test_export_smart_large_auto_scale;
+    ]);
+    ("image_fills", [
+      Alcotest.test_case "download" `Quick test_image_fills_download;
+      Alcotest.test_case "no download" `Quick test_image_fills_no_download;
+      Alcotest.test_case "api error" `Quick test_image_fills_api_error;
+    ]);
+    ("get_nodes", [
+      Alcotest.test_case "fidelity" `Quick test_get_nodes_format_fidelity;
+      Alcotest.test_case "raw" `Quick test_get_nodes_format_raw;
+      Alcotest.test_case "api error" `Quick test_get_nodes_api_error;
+      Alcotest.test_case "with opts" `Quick test_get_nodes_with_opts;
+    ]);
+    ("post_comment", [
+      Alcotest.test_case "with node_id" `Quick test_post_comment_with_node_id;
+      Alcotest.test_case "no node_id" `Quick test_post_comment_no_node_id;
+    ]);
+    ("list_screens", [
+      Alcotest.test_case "ok" `Quick test_list_screens_ok;
+      Alcotest.test_case "error" `Quick test_list_screens_error;
+    ]);
+    ("passthrough", [
+      Alcotest.test_case "file_components" `Quick test_get_file_components;
+      Alcotest.test_case "file_component_sets" `Quick test_get_file_component_sets;
+      Alcotest.test_case "file_styles" `Quick test_get_file_styles;
+      Alcotest.test_case "component" `Quick test_get_component;
+      Alcotest.test_case "component_set" `Quick test_get_component_set;
+      Alcotest.test_case "team_components" `Quick test_get_team_components;
+      Alcotest.test_case "team_component_sets" `Quick test_get_team_component_sets;
+      Alcotest.test_case "team_styles" `Quick test_get_team_styles;
+      Alcotest.test_case "file_versions" `Quick test_get_file_versions;
+      Alcotest.test_case "file_comments" `Quick test_get_file_comments;
+    ]);
+  ]

--- a/test/test_helpers_effects_w4.ml
+++ b/test/test_helpers_effects_w4.ml
@@ -1,0 +1,1132 @@
+(** Coverage Wave 4 tests for mcp_helpers.ml, figma_effects.ml, server_metrics.ml.
+    Tests mcp_helpers internal functions INDIRECTLY through exported API
+    (fidelity_score_of_dsl, fidelity_score_of_bundle, count_text_segments, etc.)
+    since the .mli hides internal helpers. *)
+
+let () =
+  Unix.putenv "FIGMA_TOKEN" "test-token-12345";
+  let open Alcotest in
+
+  (* ===== mcp_helpers.ml — remaining uncovered branches ===== *)
+
+  (* --- fidelity_score_of_dsl: exercises coverage_for_section,
+         count_assoc_fields, count_list_items, assoc_or_empty, list_member --- *)
+
+  (* All sections present and full -> high score *)
+  let test_fidelity_dsl_full () =
+    let json = `Assoc [
+      ("meta", `Assoc [("type", `String "FRAME"); ("name", `String "root")]);
+      ("meta_missing", `List []);
+      ("structure", `Assoc [("depth", `Int 2)]);
+      ("structure_missing", `List []);
+      ("geometry", `Assoc [("x", `Float 0.0); ("y", `Float 0.0)]);
+      ("geometry_missing", `List []);
+      ("layout", `Assoc [("mode", `String "NONE")]);
+      ("layout_missing", `List []);
+      ("paint", `Assoc [("fills", `List [])]);
+      ("paint_missing", `List []);
+    ] in
+    let (score, missing, _details) = Mcp_helpers.fidelity_score_of_dsl json in
+    check bool "high score" true (score > 0.5);
+    check int "0 missing" 0 missing
+  in
+
+  (* All sections empty (no keys) -> score = 1.0 (no fields = perfect coverage) *)
+  let test_fidelity_dsl_empty () =
+    let json = `Assoc [] in
+    let (score, missing, _details) = Mcp_helpers.fidelity_score_of_dsl json in
+    check (float 0.01) "empty = 1.0" 1.0 score;
+    check int "0 missing" 0 missing
+  in
+
+  (* Some sections have missing fields -> partial score *)
+  let test_fidelity_dsl_partial () =
+    let json = `Assoc [
+      ("meta", `Assoc [("type", `String "FRAME")]);
+      ("meta_missing", `List [`String "name"; `String "visible"]);
+      ("structure", `Assoc []);
+      ("structure_missing", `List [`String "depth"]);
+    ] in
+    let (score, missing, _details) = Mcp_helpers.fidelity_score_of_dsl json in
+    check bool "partial score < 1.0" true (score < 1.0);
+    check int "3 total missing" 3 missing
+  in
+
+  (* Section present but missing all -> coverage 0/N *)
+  let test_fidelity_dsl_all_missing () =
+    let json = `Assoc [
+      ("meta", `Assoc []);
+      ("meta_missing", `List [`String "type"; `String "name"]);
+      ("geometry", `Assoc []);
+      ("geometry_missing", `List [`String "x"; `String "y"; `String "w"]);
+    ] in
+    let (score, missing, _details) = Mcp_helpers.fidelity_score_of_dsl json in
+    check bool "low score" true (score < 1.0);
+    check int "5 total missing" 5 missing
+  in
+
+  (* --- fidelity_score_with_overrides: explicit override replaces section --- *)
+  let test_fidelity_with_overrides () =
+    let json = `Assoc [
+      ("meta", `Assoc [("type", `String "FRAME")]);
+      ("meta_missing", `List [`String "name"]);
+    ] in
+    (* Override meta to be perfect *)
+    let overrides = [("meta", (1.0, 5, 0, 5))] in
+    let (score, missing, details) = Mcp_helpers.fidelity_score_with_overrides json overrides in
+    (* meta override -> 5 present, 0 missing *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "meta" lst with
+          | Some (`Assoc fields) ->
+              check (float 0.01) "override score" 1.0
+                (match List.assoc_opt "score" fields with Some (`Float f) -> f | _ -> -1.0);
+              check int "override present" 5
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected meta details")
+     | _ -> fail "expected assoc details");
+    (* Only non-overridden sections contribute to missing *)
+    check bool "score improved" true (score > 0.0);
+    ignore missing
+  in
+
+  (* Override with explicit score value *)
+  let test_override_section_with_score () =
+    let (score, present, missing, total) =
+      Mcp_helpers.override_section ~score:0.75 ~present:3 ~missing:1 ~total:4 ()
+    in
+    check (float 0.01) "custom score" 0.75 score;
+    check int "present" 3 present;
+    check int "missing" 1 missing;
+    check int "total" 4 total
+  in
+
+  (* Override without explicit score -> computed from present/total *)
+  let test_override_section_auto_score () =
+    let (score, present, missing, total) =
+      Mcp_helpers.override_section ~present:2 ~missing:3 ~total:5 ()
+    in
+    check (float 0.01) "auto score" 0.4 score;
+    check int "present" 2 present;
+    check int "missing" 3 missing;
+    check int "total" 5 total
+  in
+
+  (* Override with total = 0 -> score = 1.0 *)
+  let test_override_section_zero_total () =
+    let (score, _, _, _) =
+      Mcp_helpers.override_section ~present:0 ~missing:0 ~total:0 ()
+    in
+    check (float 0.01) "zero total = 1.0" 1.0 score
+  in
+
+  (* --- fidelity_score_of_bundle: exercises image_refs_of_dsl,
+         image_fill_map, plugin_ok, count_text_nodes_dsl,
+         count_text_nodes_with_segments, plugin_text_nodes_with_segments,
+         variables_counts, string_list_of_json --- *)
+
+  (* include_image_fills with refs that match *)
+  let test_bundle_image_fills_match () =
+    let dsl_json = `Assoc [
+      ("assets", `Assoc [
+        ("image_refs", `List [`String "ref1"; `String "ref2"; `String "ref3"])
+      ]);
+      ("assets_missing", `List []);
+    ] in
+    let image_fills = `Assoc [
+      ("images", `Assoc [
+        ("ref1", `String "https://example.com/img1.png");
+        ("ref2", `String "https://example.com/img2.png");
+      ])
+    ] in
+    let (score, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:true ~include_plugin:false
+    in
+    check bool "score > 0" true (score > 0.0);
+    (* assets override: 2 present out of 3 refs *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "assets" lst with
+          | Some (`Assoc fields) ->
+              check int "present" 2
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1);
+              check int "total" 3
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected assets details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_image_fills with no refs -> no override *)
+  let test_bundle_image_fills_no_refs () =
+    let dsl_json = `Assoc [
+      ("assets", `Assoc [("other", `String "x")]);
+    ] in
+    let image_fills = `Assoc [("images", `Assoc [("r", `String "u")])] in
+    let (_score, _, _details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:true ~include_plugin:false
+    in
+    ()  (* no crash = success, assets not overridden *)
+  in
+
+  (* include_image_fills with non-assoc image_fills *)
+  let test_bundle_image_fills_non_assoc () =
+    let dsl_json = `Assoc [
+      ("assets", `Assoc [
+        ("image_refs", `List [`String "ref1"])
+      ]);
+    ] in
+    let (_score, _, _) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:true ~include_plugin:false
+    in
+    ()  (* image_fill_map returns [] for non-assoc, so 0 present *)
+  in
+
+  (* include_image_fills: mixed types in image_refs (non-string filtered) *)
+  let test_bundle_image_refs_mixed () =
+    let dsl_json = `Assoc [
+      ("assets", `Assoc [
+        ("image_refs", `List [`String "r1"; `Int 42; `Bool true; `String "r2"])
+      ]);
+    ] in
+    let image_fills = `Assoc [("images", `Assoc [("r1", `String "url1")])] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:true ~include_plugin:false
+    in
+    (* Only 2 string refs: r1 and r2. r1 matched, r2 not. total=2, present=1 *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "assets" lst with
+          | Some (`Assoc fields) ->
+              check int "total 2 string refs" 2
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1);
+              check int "present 1" 1
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected assets details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_image_fills: non-assoc assets in dsl -> no refs *)
+  let test_bundle_image_fills_bad_assets () =
+    let dsl_json = `Assoc [("assets", `String "bad")] in
+    let (_score, _, _) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:true ~include_plugin:false
+    in
+    ()
+  in
+
+  (* include_image_fills: images key not assoc *)
+  let test_bundle_image_fills_images_not_assoc () =
+    let dsl_json = `Assoc [
+      ("assets", `Assoc [("image_refs", `List [`String "r1"])]);
+    ] in
+    let image_fills = `Assoc [("images", `List [])] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:true ~include_plugin:false
+    in
+    (* image_fill_map returns [] for non-assoc images, so 0 present *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "assets" lst with
+          | Some (`Assoc fields) ->
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected assets details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin with ok=true plugin -> text_segments override *)
+  let test_bundle_plugin_ok () =
+    let text_node = `Assoc [("meta", `Assoc [("type", `String "TEXT")])] in
+    let dsl_json = `Assoc [
+      ("children", `List [text_node; text_node; text_node]);
+    ] in
+    let plugin_snapshot = `Assoc [
+      ("ok", `Bool true);
+      ("payload", `Assoc [
+        ("text", `Assoc [("segments", `List [`String "s1"])]);
+        ("children", `List [
+          `Assoc [("text", `Assoc [("segments", `List [`String "s2"])])];
+        ]);
+      ]);
+    ] in
+    let (score, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    check bool "score > 0" true (score > 0.0);
+    (* plugin override: text_segments section with 2 present out of 3 text nodes *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "text_segments" lst with
+          | Some (`Assoc fields) ->
+              check int "present 2" 2
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1);
+              check int "total 3" 3
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected text_segments details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin with ok=false -> plugin section override (0/1) *)
+  let test_bundle_plugin_not_ok () =
+    let plugin_snapshot = `Assoc [("ok", `Bool false)] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "plugin" lst with
+          | Some (`Assoc fields) ->
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1);
+              check int "total 1" 1
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected plugin details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin with ok=true but 0 text nodes -> no text_segments override *)
+  let test_bundle_plugin_ok_no_text () =
+    let dsl_json = `Assoc [
+      ("meta", `Assoc [("type", `String "FRAME")]);
+    ] in
+    let plugin_snapshot = `Assoc [("ok", `Bool true); ("payload", `Assoc [])] in
+    let (_score, _, _details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    ()  (* no text nodes -> text_segments not overridden *)
+  in
+
+  (* include_plugin: missing ok field -> plugin_ok = false *)
+  let test_bundle_plugin_missing_ok () =
+    let plugin_snapshot = `Assoc [("payload", `Assoc [])] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "plugin" lst with
+          | Some (`Assoc fields) ->
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected plugin details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin: ok is non-bool -> plugin_ok = false *)
+  let test_bundle_plugin_ok_non_bool () =
+    let plugin_snapshot = `Assoc [("ok", `String "yes")] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "plugin" lst with
+          | Some (`Assoc fields) ->
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected plugin details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin: non-assoc plugin_snapshot -> plugin_ok false *)
+  let test_bundle_plugin_non_assoc () =
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables:`Null ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "plugin" lst with
+          | Some (`Assoc fields) ->
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected plugin details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin: nested text nodes in dsl *)
+  let test_bundle_plugin_nested_text () =
+    let text_node = `Assoc [("meta", `Assoc [("type", `String "TEXT")])] in
+    let frame = `Assoc [
+      ("meta", `Assoc [("type", `String "FRAME")]);
+      ("children", `List [text_node; text_node]);
+    ] in
+    let dsl_json = `Assoc [("children", `List [frame; text_node])] in
+    (* 3 total text nodes: 2 nested + 1 direct *)
+    let seg_node = `Assoc [("text", `Assoc [("segments", `List [`String "s"])])] in
+    let plugin_snapshot = `Assoc [
+      ("ok", `Bool true);
+      ("payload", `Assoc [("children", `List [seg_node])]);
+    ] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "text_segments" lst with
+          | Some (`Assoc fields) ->
+              check int "total 3" 3
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1);
+              check int "present 1" 1
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected text_segments details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_plugin: plugin_text_nodes_with_segments with no payload *)
+  let test_bundle_plugin_no_payload () =
+    let text_node = `Assoc [("meta", `Assoc [("type", `String "TEXT")])] in
+    let dsl_json = `Assoc [("children", `List [text_node])] in
+    let plugin_snapshot = `Assoc [("ok", `Bool true)] in  (* no payload key *)
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables:`Null ~image_fills:`Null ~plugin_snapshot
+      ~include_variables:false ~include_image_fills:false ~include_plugin:true
+    in
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "text_segments" lst with
+          | Some (`Assoc fields) ->
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected text_segments details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_variables with resolved/raw data *)
+  let test_bundle_variables_ok () =
+    let variables = `Assoc [
+      ("variables", `Assoc [("v1", `String "a"); ("v2", `String "b")]);
+      ("resolved", `Assoc [("v1", `String "resolved_a")]);
+    ] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:true ~include_image_fills:false ~include_plugin:false
+    in
+    (* variables_counts returns (2, 1) -> total=2, present=1 *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "variables_resolved" lst with
+          | Some (`Assoc fields) ->
+              check int "total 2" 2
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1);
+              check int "present 1" 1
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected variables_resolved details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_variables with error *)
+  let test_bundle_variables_error () =
+    let variables = `Assoc [("error", `String "no access")] in
+    let (_, _, details) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:true ~include_image_fills:false ~include_plugin:false
+    in
+    (* variables_counts for error returns (1, 0) -> total=1, present=0 *)
+    (match details with
+     | `Assoc lst ->
+         (match List.assoc_opt "variables_resolved" lst with
+          | Some (`Assoc fields) ->
+              check int "total 1" 1
+                (match List.assoc_opt "total" fields with Some (`Int n) -> n | _ -> -1);
+              check int "present 0" 0
+                (match List.assoc_opt "present" fields with Some (`Int n) -> n | _ -> -1)
+          | _ -> fail "expected variables_resolved details")
+     | _ -> fail "expected assoc details")
+  in
+
+  (* include_variables with non-assoc -> (0, 0) -> no override *)
+  let test_bundle_variables_non_assoc () =
+    let (_, _, _) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables:`Null ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:true ~include_image_fills:false ~include_plugin:false
+    in
+    ()  (* variables_counts returns (0, 0), total=0 -> no override *)
+  in
+
+  (* include_variables with empty assoc -> (0, 0) -> no override *)
+  let test_bundle_variables_empty () =
+    let variables = `Assoc [] in
+    let (_, _, _) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json:(`Assoc []) ~variables ~image_fills:`Null ~plugin_snapshot:`Null
+      ~include_variables:true ~include_image_fills:false ~include_plugin:false
+    in
+    ()
+  in
+
+  (* All flags enabled *)
+  let test_bundle_all_flags () =
+    let text_node = `Assoc [("meta", `Assoc [("type", `String "TEXT")])] in
+    let dsl_json = `Assoc [
+      ("children", `List [text_node]);
+      ("assets", `Assoc [("image_refs", `List [`String "r1"])]);
+    ] in
+    let image_fills = `Assoc [("images", `Assoc [("r1", `String "url")])] in
+    let variables = `Assoc [
+      ("variables", `Assoc [("v1", `String "x")]);
+      ("resolved", `Assoc [("v1", `String "y")]);
+    ] in
+    let plugin_snapshot = `Assoc [
+      ("ok", `Bool true);
+      ("payload", `Assoc [
+        ("text", `Assoc [("segments", `List [`String "s"])]);
+      ]);
+    ] in
+    let (score, _, _) = Mcp_helpers.fidelity_score_of_bundle
+      ~dsl_json ~variables ~image_fills ~plugin_snapshot
+      ~include_variables:true ~include_image_fills:true ~include_plugin:true
+    in
+    check bool "score > 0" true (score > 0.0)
+  in
+
+  (* --- count_text_segments (directly exported) --- *)
+  let test_count_text_segments_one () =
+    let json = `Assoc [
+      ("text", `Assoc [("segments", `List [`String "s1"; `String "s2"])]);
+    ] in
+    check int "2 segments" 2 (Mcp_helpers.count_text_segments json)
+  in
+  let test_count_text_segments_no_segments () =
+    let json = `Assoc [("text", `Assoc [("value", `String "hello")])] in
+    check int "0 segments" 0 (Mcp_helpers.count_text_segments json)
+  in
+  let test_count_text_segments_no_text () =
+    let json = `Assoc [("meta", `Assoc [])] in
+    check int "0" 0 (Mcp_helpers.count_text_segments json)
+  in
+  let test_count_text_segments_nested () =
+    let child = `Assoc [("text", `Assoc [("segments", `List [`String "s"])])] in
+    let parent = `Assoc [("children", `List [child; child])] in
+    check int "2 nested" 2 (Mcp_helpers.count_text_segments parent)
+  in
+  let test_count_text_segments_list () =
+    let node = `Assoc [("text", `Assoc [("segments", `List [`String "s"])])] in
+    check int "3 from list" 3 (Mcp_helpers.count_text_segments (`List [node; node; node]))
+  in
+  let test_count_text_segments_primitive () =
+    check int "null" 0 (Mcp_helpers.count_text_segments `Null);
+    check int "int" 0 (Mcp_helpers.count_text_segments (`Int 1))
+  in
+
+  (* --- plugin_payload_if_ok (directly exported) --- *)
+  let test_plugin_payload_if_ok_true () =
+    let json = `Assoc [("ok", `Bool true); ("payload", `Assoc [("data", `Int 1)])] in
+    match Mcp_helpers.plugin_payload_if_ok json with
+    | Some (`Assoc _) -> ()
+    | _ -> fail "expected Some payload"
+  in
+  let test_plugin_payload_if_ok_false () =
+    let json = `Assoc [("ok", `Bool false); ("payload", `Assoc [])] in
+    check bool "false -> None" true (Mcp_helpers.plugin_payload_if_ok json = None)
+  in
+  let test_plugin_payload_if_ok_no_ok () =
+    let json = `Assoc [("payload", `Assoc [])] in
+    check bool "no ok -> None" true (Mcp_helpers.plugin_payload_if_ok json = None)
+  in
+  let test_plugin_payload_if_ok_no_payload () =
+    let json = `Assoc [("ok", `Bool true)] in
+    check bool "no payload -> None" true (Mcp_helpers.plugin_payload_if_ok json = None)
+  in
+  let test_plugin_payload_if_ok_non_assoc () =
+    check bool "null -> None" true (Mcp_helpers.plugin_payload_if_ok `Null = None);
+    check bool "list -> None" true (Mcp_helpers.plugin_payload_if_ok (`List []) = None)
+  in
+
+  (* --- resolve_plugin_variables (directly exported) --- *)
+  let test_resolve_plugin_variables_ok () =
+    let payload = `Assoc [
+      ("collections", `Assoc []);
+      ("variables", `Assoc [
+        ("v1", `Assoc [
+          ("name", `String "test");
+          ("valuesByMode", `Assoc [("mode1", `String "val1")]);
+        ])
+      ]);
+    ] in
+    let result = Mcp_helpers.resolve_plugin_variables payload in
+    match result with
+    | `Assoc _ -> ()  (* valid structure *)
+    | _ -> fail "expected assoc"
+  in
+  let test_resolve_plugin_variables_no_collections () =
+    let payload = `Assoc [("variables", `Assoc [])] in
+    let result = Mcp_helpers.resolve_plugin_variables payload in
+    match result with
+    | `Assoc lst ->
+        check bool "error" true (List.assoc_opt "error" lst <> None)
+    | _ -> fail "expected assoc"
+  in
+  let test_resolve_plugin_variables_non_assoc () =
+    let result = Mcp_helpers.resolve_plugin_variables `Null in
+    match result with
+    | `Assoc lst ->
+        check bool "error" true (List.assoc_opt "error" lst <> None)
+    | _ -> fail "expected assoc"
+  in
+
+  (* --- classify_http_error: edge cases --- *)
+  let test_classify_429_with_float () =
+    match Mcp_helpers.classify_http_error ~status_code:429 ~body:"retry after 45.5" with
+    | Mcp_helpers.RateLimited secs -> check (float 0.1) "parsed" 45.5 secs
+    | _ -> fail "expected RateLimited"
+  in
+  let test_classify_400 () =
+    match Mcp_helpers.classify_http_error ~status_code:400 ~body:"bad request" with
+    | Mcp_helpers.UnknownError _ -> ()
+    | _ -> fail "expected UnknownError"
+  in
+  let test_classify_301 () =
+    match Mcp_helpers.classify_http_error ~status_code:301 ~body:"moved" with
+    | Mcp_helpers.UnknownError _ -> ()
+    | _ -> fail "expected UnknownError"
+  in
+
+  (* --- resolve_variables edge: empty valuesByMode --- *)
+  let test_resolve_variables_empty_values_by_mode () =
+    let json = `Assoc [
+      ("meta", `Assoc [
+        ("variableCollections", `Assoc []);
+        ("variables", `Assoc [
+          ("var1", `Assoc [
+            ("name", `String "test");
+            ("valuesByMode", `Assoc []);
+          ])
+        ])
+      ])
+    ] in
+    let result = Mcp_helpers.resolve_variables json in
+    match result with
+    | `Assoc lst ->
+        (match List.assoc_opt "resolved" lst with
+         | Some (`Assoc [("var1", `Assoc fields)]) ->
+             check bool "null default" true
+               (List.assoc_opt "defaultValue" fields = Some `Null)
+         | _ -> fail "expected resolved")
+    | _ -> fail "expected assoc"
+  in
+
+  (* --- resolve_variables: non-assoc variables --- *)
+  let test_resolve_variables_non_assoc_variables () =
+    let json = `Assoc [
+      ("meta", `Assoc [
+        ("variableCollections", `Assoc []);
+        ("variables", `String "bad");
+      ])
+    ] in
+    let result = Mcp_helpers.resolve_variables json in
+    match result with
+    | `Assoc lst ->
+        check bool "null resolved" true (List.assoc_opt "resolved" lst = Some `Null)
+    | _ -> fail "expected assoc"
+  in
+
+  (* --- process_json_string with "pixel" and "accuracy" formats --- *)
+  let test_process_json_pixel () =
+    let json_str = Yojson.Safe.to_string (`Assoc [("type", `String "FRAME")]) in
+    match Mcp_helpers.process_json_string ~format:"pixel" json_str with
+    | Ok s -> check bool "pixel output" true (String.length s > 0)
+    | Error e -> fail (Printf.sprintf "pixel error: %s" e)
+  in
+  let test_process_json_accuracy () =
+    let json_str = Yojson.Safe.to_string (`Assoc [("type", `String "FRAME")]) in
+    match Mcp_helpers.process_json_string ~format:"accuracy" json_str with
+    | Ok s -> check bool "accuracy output" true (String.length s > 0)
+    | Error e -> fail (Printf.sprintf "accuracy error: %s" e)
+  in
+
+  (* --- make_error_json with empty debug_info (no debug field) --- *)
+  let test_make_error_json_empty_debug () =
+    let result = Mcp_helpers.make_error_json ~operation:"op"
+      ~error:(Mcp_helpers.NetworkError "net") ~debug_info:[] () in
+    match result with
+    | `Assoc lst ->
+        check bool "no debug" true (List.assoc_opt "debug" lst = None)
+    | _ -> fail "expected assoc"
+  in
+
+  (* --- eio_context_key (Domain.DLS) --- *)
+  let test_get_eio_context_none () =
+    let ctx = Mcp_helpers.get_eio_context () in
+    ignore ctx  (* may or may not be None depending on other tests *)
+  in
+
+  (* --- member (directly exported) --- *)
+  let test_member_found () =
+    let json = `Assoc [("key", `String "val")] in
+    match Mcp_helpers.member "key" json with
+    | Some (`String "val") -> ()
+    | _ -> fail "expected Some string"
+  in
+  let test_member_missing () =
+    let json = `Assoc [("other", `Int 1)] in
+    check bool "missing" true (Mcp_helpers.member "key" json = None)
+  in
+  let test_member_non_assoc () =
+    check bool "null" true (Mcp_helpers.member "key" `Null = None)
+  in
+
+  (* ===== figma_effects.ml — additional branches ===== *)
+
+  (* --- create_mock_store: verify all hashtable fields --- *)
+  let test_effects_create_mock_store_fresh () =
+    let s = Figma_effects.create_mock_store () in
+    check int "files" 0 (Hashtbl.length s.files);
+    check int "nodes" 0 (Hashtbl.length s.nodes);
+    check int "images" 0 (Hashtbl.length s.images);
+    check int "file_images" 0 (Hashtbl.length s.file_images);
+    check int "file_meta" 0 (Hashtbl.length s.file_meta);
+    check bool "me none" true (!(s.me) = None);
+    check int "projects" 0 (Hashtbl.length s.projects);
+    check int "project_files" 0 (Hashtbl.length s.project_files);
+    check int "variables" 0 (Hashtbl.length s.variables)
+  in
+
+  (* --- run_with_mock: exercise exception path --- *)
+  let test_run_with_mock_exception () =
+    let store = Figma_effects.create_mock_store () in
+    let raised = ref false in
+    (try
+      Figma_effects.run_with_mock store (fun () ->
+        failwith "test exception"
+      )
+    with Failure msg ->
+      raised := true;
+      check string "msg" "test exception" msg);
+    check bool "raised" true !raised
+  in
+
+  (* --- run_with_mock: pure computation (no effects) --- *)
+  let test_run_with_mock_pure () =
+    let store = Figma_effects.create_mock_store () in
+    let result = Figma_effects.run_with_mock store (fun () -> 42) in
+    check int "pure value" 42 result
+  in
+
+  (* --- run_with_mock with populated store: verify me ref works --- *)
+  let test_run_with_mock_me_set_unset () =
+    let store = Figma_effects.create_mock_store () in
+    (* me not set *)
+    let r1 = Figma_effects.run_with_mock store (fun () ->
+      Figma_effects.Perform.get_me ~token:"tk"
+    ) in
+    check bool "me not set" true (Result.is_error r1);
+    (* set me *)
+    store.me := Some (`Assoc [("id", `String "u1")]);
+    let r2 = Figma_effects.run_with_mock store (fun () ->
+      Figma_effects.Perform.get_me ~token:"tk"
+    ) in
+    check bool "me set" true (Result.is_ok r2)
+  in
+
+  (* --- make_neo4j_statement with complex params --- *)
+  let test_neo4j_statement_complex_params () =
+    let stmt = Figma_effects.make_neo4j_statement
+      "MERGE (n:Node {id: $id}) SET n.tags = $tags"
+      [("id", `String "n1"); ("tags", `List [`String "a"; `String "b"])]
+    in
+    match stmt with
+    | `Assoc fields ->
+        (match List.assoc_opt "parameters" fields with
+         | Some (`Assoc params) ->
+             check bool "has id" true (List.assoc_opt "id" params = Some (`String "n1"));
+             (match List.assoc_opt "tags" params with
+              | Some (`List _) -> ()
+              | _ -> fail "expected tags list")
+         | _ -> fail "expected params")
+    | _ -> fail "expected assoc"
+  in
+
+  (* --- parse_neo4j_response edge: errors with partial code/message --- *)
+  let test_parse_neo4j_partial_error () =
+    let body = {|{"results":[],"errors":[{"code":"Neo.Err","message":""}]}|} in
+    match Figma_effects.parse_neo4j_response body with
+    | Error msg -> check bool "has code" true (String.length msg > 0)
+    | Ok _ -> fail "expected error"
+  in
+  let test_parse_neo4j_only_message () =
+    let body = {|{"results":[],"errors":[{"code":"","message":"something wrong"}]}|} in
+    match Figma_effects.parse_neo4j_response body with
+    | Error msg -> check bool "has message" true (String.length msg > 0)
+    | Ok _ -> fail "expected error"
+  in
+
+  (* --- parse_neo4j_response: no results field --- *)
+  let test_parse_neo4j_no_results () =
+    let body = {|{"errors":[]}|} in
+    match Figma_effects.parse_neo4j_response body with
+    | Ok _ -> ()
+    | Error e -> fail (Printf.sprintf "unexpected error: %s" e)
+  in
+
+  (* --- run_with_mock: multiple sequential effects in one run --- *)
+  let test_run_with_mock_multi_effects () =
+    let store = Figma_effects.create_mock_store () in
+    Hashtbl.replace store.files "f1" (`Assoc [("name", `String "File1")]);
+    Hashtbl.replace store.variables "f1" (`Assoc [("vars", `Assoc [])]);
+    store.me := Some (`Assoc [("id", `String "me")]);
+    let result = Figma_effects.run_with_mock store (fun () ->
+      Figma_effects.Perform.log_info "start";
+      let f = Figma_effects.Perform.get_file ~token:"t" ~file_key:"f1" () in
+      Figma_effects.Perform.log_debug "got file";
+      let v = Figma_effects.Perform.get_variables ~token:"t" ~file_key:"f1" in
+      Figma_effects.Perform.log_error "test error log";
+      Figma_effects.Perform.eio_sleep 0.1;
+      let m = Figma_effects.Perform.get_me ~token:"t" in
+      (f, v, m)
+    ) in
+    let (f, v, m) = result in
+    check bool "file ok" true (Result.is_ok f);
+    check bool "vars ok" true (Result.is_ok v);
+    check bool "me ok" true (Result.is_ok m)
+  in
+
+  (* ===== server_metrics.ml — target 60%+ ===== *)
+
+  (* --- prom_metric (pure function) --- *)
+  let test_prom_metric_basic () =
+    let result = Server_metrics.prom_metric "test_metric" "label=\"val\"" "42" in
+    check string "format" "test_metric{label=\"val\"} 42\n" result
+  in
+  let test_prom_metric_empty_labels () =
+    let result = Server_metrics.prom_metric "m" "" "0" in
+    check string "empty labels" "m{} 0\n" result
+  in
+  let test_prom_metric_float_value () =
+    let result = Server_metrics.prom_metric "latency" "q=\"p50\"" "1.234" in
+    check string "float" "latency{q=\"p50\"} 1.234\n" result
+  in
+
+  (* --- snapshot, to_json, to_prometheus_text via Eio_main.run --- *)
+  let test_snapshot_initial () =
+    Eio_main.run @@ fun _env ->
+    let s = Server_metrics.snapshot () in
+    check bool "inflight >= 0" true (s.inflight >= 0);
+    check bool "total >= 0" true (s.total >= 0);
+    check bool "updated_at > 0" true (s.updated_at > 0.0)
+  in
+
+  let test_to_json () =
+    Eio_main.run @@ fun _env ->
+    let json = Server_metrics.to_json () in
+    match json with
+    | `Assoc lst ->
+        check bool "has inflight" true (List.assoc_opt "inflight" lst <> None);
+        check bool "has total" true (List.assoc_opt "total" lst <> None);
+        check bool "has status_2xx" true (List.assoc_opt "status_2xx" lst <> None);
+        check bool "has status_3xx" true (List.assoc_opt "status_3xx" lst <> None);
+        check bool "has status_4xx" true (List.assoc_opt "status_4xx" lst <> None);
+        check bool "has status_5xx" true (List.assoc_opt "status_5xx" lst <> None);
+        check bool "has errors" true (List.assoc_opt "errors" lst <> None);
+        check bool "has bytes_out" true (List.assoc_opt "bytes_out" lst <> None);
+        check bool "has sse_open" true (List.assoc_opt "sse_open" lst <> None);
+        check bool "has sse_total" true (List.assoc_opt "sse_total" lst <> None);
+        check bool "has rps_1m" true (List.assoc_opt "rps_1m" lst <> None);
+        check bool "has rps_5m" true (List.assoc_opt "rps_5m" lst <> None);
+        check bool "has latency_ms" true (List.assoc_opt "latency_ms" lst <> None);
+        check bool "has updated_at" true (List.assoc_opt "updated_at" lst <> None);
+        (match List.assoc_opt "latency_ms" lst with
+         | Some (`Assoc lat) ->
+             check bool "lat count" true (List.assoc_opt "count" lat <> None);
+             check bool "lat avg" true (List.assoc_opt "avg" lat <> None);
+             check bool "lat p50" true (List.assoc_opt "p50" lat <> None);
+             check bool "lat p95" true (List.assoc_opt "p95" lat <> None);
+             check bool "lat p99" true (List.assoc_opt "p99" lat <> None);
+             check bool "lat min" true (List.assoc_opt "min" lat <> None);
+             check bool "lat max" true (List.assoc_opt "max" lat <> None)
+         | _ -> fail "expected latency_ms assoc")
+    | _ -> fail "expected assoc"
+  in
+
+  let test_to_prometheus_text () =
+    Eio_main.run @@ fun _env ->
+    let text = Server_metrics.to_prometheus_text () in
+    check bool "has header" true (String.length text > 0);
+    let has_str s = try let _ = Str.search_forward (Str.regexp_string s) text 0 in true with Not_found -> false in
+    check bool "has HELP total" true (has_str "# HELP mcp_http_requests_total");
+    check bool "has TYPE total" true (has_str "# TYPE mcp_http_requests_total counter");
+    check bool "has inflight metric" true (has_str "mcp_http_inflight");
+    check bool "has errors metric" true (has_str "mcp_http_errors_total");
+    check bool "has rps_1m metric" true (has_str "mcp_http_rps_1m");
+    check bool "has rps_5m metric" true (has_str "mcp_http_rps_5m");
+    check bool "has sse_open metric" true (has_str "mcp_sse_open");
+    check bool "has sse_total metric" true (has_str "mcp_sse_total");
+    check bool "has latency metric" true (has_str "mcp_http_latency_ms");
+    check bool "has 2xx class" true (has_str "class=\"2xx\"");
+    check bool "has 3xx class" true (has_str "class=\"3xx\"");
+    check bool "has 4xx class" true (has_str "class=\"4xx\"");
+    check bool "has 5xx class" true (has_str "class=\"5xx\"");
+    check bool "has quantile p50" true (has_str "quantile=\"0.50\"");
+    check bool "has quantile p95" true (has_str "quantile=\"0.95\"");
+    check bool "has quantile p99" true (has_str "quantile=\"0.99\"");
+    check bool "has stat avg" true (has_str "stat=\"avg\"");
+    check bool "has stat min" true (has_str "stat=\"min\"");
+    check bool "has stat max" true (has_str "stat=\"max\"")
+  in
+
+  (* --- sse_open / sse_close --- *)
+  let test_sse_open_close () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    Server_metrics.sse_open ();
+    let after_open = Server_metrics.snapshot () in
+    check int "sse_open +1" (before.sse_open + 1) after_open.sse_open;
+    check int "sse_total +1" (before.sse_total + 1) after_open.sse_total;
+    Server_metrics.sse_close ();
+    let after_close = Server_metrics.snapshot () in
+    check int "sse_open back" before.sse_open after_close.sse_open;
+    check int "sse_total unchanged" after_open.sse_total after_close.sse_total
+  in
+
+  (* --- sse_close when already 0 --- *)
+  let test_sse_close_floor () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    for _ = 1 to before.sse_open + 1 do
+      Server_metrics.sse_close ()
+    done;
+    let after = Server_metrics.snapshot () in
+    check bool "sse_open >= 0" true (after.sse_open >= 0)
+  in
+
+  (* --- record_untracked_response: 2xx --- *)
+  let test_record_untracked_2xx () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    Server_metrics.record_untracked_response `OK;
+    let after = Server_metrics.snapshot () in
+    check int "total +1" (before.total + 1) after.total;
+    check int "2xx +1" (before.status_2xx + 1) after.status_2xx;
+    check int "errors same" before.errors after.errors
+  in
+
+  (* --- record_untracked_response: 3xx --- *)
+  let test_record_untracked_3xx () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    Server_metrics.record_untracked_response `Moved_permanently;
+    let after = Server_metrics.snapshot () in
+    check int "total +1" (before.total + 1) after.total;
+    check int "3xx +1" (before.status_3xx + 1) after.status_3xx;
+    check int "errors same" before.errors after.errors
+  in
+
+  (* --- record_untracked_response: no bytes --- *)
+  let test_record_untracked_no_bytes () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    Server_metrics.record_untracked_response `OK;
+    let after = Server_metrics.snapshot () in
+    check int "bytes unchanged" before.bytes_out after.bytes_out
+  in
+
+  (* --- record_untracked_response: with bytes on 2xx --- *)
+  let test_record_untracked_with_bytes () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    Server_metrics.record_untracked_response ~bytes:500 `OK;
+    let after = Server_metrics.snapshot () in
+    check int "bytes +500" (before.bytes_out + 500) after.bytes_out
+  in
+
+  (* --- latency snapshot fields --- *)
+  let test_latency_empty_snapshot () =
+    Eio_main.run @@ fun _env ->
+    let s = Server_metrics.snapshot () in
+    check bool "count >= 0" true (s.latency.count >= 0);
+    check bool "avg >= 0" true (s.latency.avg_ms >= 0.0);
+    check bool "p50 >= 0" true (s.latency.p50_ms >= 0.0);
+    check bool "p95 >= 0" true (s.latency.p95_ms >= 0.0);
+    check bool "p99 >= 0" true (s.latency.p99_ms >= 0.0);
+    check bool "min >= 0" true (s.latency.min_ms >= 0.0);
+    check bool "max >= 0" true (s.latency.max_ms >= 0.0)
+  in
+
+  (* --- multiple record_untracked in sequence --- *)
+  let test_record_untracked_sequence () =
+    Eio_main.run @@ fun _env ->
+    let before = Server_metrics.snapshot () in
+    Server_metrics.record_untracked_response `OK;
+    Server_metrics.record_untracked_response `Not_found;
+    Server_metrics.record_untracked_response `Internal_server_error;
+    Server_metrics.record_untracked_response ~bytes:100 `OK;
+    let after = Server_metrics.snapshot () in
+    check int "total +4" (before.total + 4) after.total;
+    check int "2xx +2" (before.status_2xx + 2) after.status_2xx;
+    check int "4xx +1" (before.status_4xx + 1) after.status_4xx;
+    check int "5xx +1" (before.status_5xx + 1) after.status_5xx;
+    check int "errors +2" (before.errors + 2) after.errors
+  in
+
+  run "helpers-effects-w4" [
+    (* mcp_helpers.ml — fidelity score functions *)
+    ("fidelity_score_of_dsl", [
+      test_case "full" `Quick test_fidelity_dsl_full;
+      test_case "empty" `Quick test_fidelity_dsl_empty;
+      test_case "partial" `Quick test_fidelity_dsl_partial;
+      test_case "all missing" `Quick test_fidelity_dsl_all_missing;
+    ]);
+    ("fidelity_with_overrides", [
+      test_case "override section" `Quick test_fidelity_with_overrides;
+    ]);
+    ("override_section", [
+      test_case "with score" `Quick test_override_section_with_score;
+      test_case "auto score" `Quick test_override_section_auto_score;
+      test_case "zero total" `Quick test_override_section_zero_total;
+    ]);
+
+    (* mcp_helpers.ml — fidelity_score_of_bundle + image fills *)
+    ("bundle image_fills", [
+      test_case "match" `Quick test_bundle_image_fills_match;
+      test_case "no refs" `Quick test_bundle_image_fills_no_refs;
+      test_case "non-assoc" `Quick test_bundle_image_fills_non_assoc;
+      test_case "mixed refs" `Quick test_bundle_image_refs_mixed;
+      test_case "bad assets" `Quick test_bundle_image_fills_bad_assets;
+      test_case "images not assoc" `Quick test_bundle_image_fills_images_not_assoc;
+    ]);
+
+    (* mcp_helpers.ml — fidelity_score_of_bundle + plugin *)
+    ("bundle plugin", [
+      test_case "ok" `Quick test_bundle_plugin_ok;
+      test_case "not ok" `Quick test_bundle_plugin_not_ok;
+      test_case "ok no text" `Quick test_bundle_plugin_ok_no_text;
+      test_case "missing ok" `Quick test_bundle_plugin_missing_ok;
+      test_case "ok non-bool" `Quick test_bundle_plugin_ok_non_bool;
+      test_case "non-assoc" `Quick test_bundle_plugin_non_assoc;
+      test_case "nested text" `Quick test_bundle_plugin_nested_text;
+      test_case "no payload" `Quick test_bundle_plugin_no_payload;
+    ]);
+
+    (* mcp_helpers.ml — fidelity_score_of_bundle + variables *)
+    ("bundle variables", [
+      test_case "ok" `Quick test_bundle_variables_ok;
+      test_case "error" `Quick test_bundle_variables_error;
+      test_case "non-assoc" `Quick test_bundle_variables_non_assoc;
+      test_case "empty" `Quick test_bundle_variables_empty;
+    ]);
+
+    (* mcp_helpers.ml — all flags *)
+    ("bundle all flags", [
+      test_case "all enabled" `Quick test_bundle_all_flags;
+    ]);
+
+    (* mcp_helpers.ml — count_text_segments (exported) *)
+    ("count_text_segments", [
+      test_case "one" `Quick test_count_text_segments_one;
+      test_case "no segments" `Quick test_count_text_segments_no_segments;
+      test_case "no text" `Quick test_count_text_segments_no_text;
+      test_case "nested" `Quick test_count_text_segments_nested;
+      test_case "list" `Quick test_count_text_segments_list;
+      test_case "primitive" `Quick test_count_text_segments_primitive;
+    ]);
+
+    (* mcp_helpers.ml — plugin_payload_if_ok (exported) *)
+    ("plugin_payload_if_ok", [
+      test_case "true" `Quick test_plugin_payload_if_ok_true;
+      test_case "false" `Quick test_plugin_payload_if_ok_false;
+      test_case "no ok" `Quick test_plugin_payload_if_ok_no_ok;
+      test_case "no payload" `Quick test_plugin_payload_if_ok_no_payload;
+      test_case "non-assoc" `Quick test_plugin_payload_if_ok_non_assoc;
+    ]);
+
+    (* mcp_helpers.ml — resolve_plugin_variables (exported) *)
+    ("resolve_plugin_variables", [
+      test_case "ok" `Quick test_resolve_plugin_variables_ok;
+      test_case "no collections" `Quick test_resolve_plugin_variables_no_collections;
+      test_case "non-assoc" `Quick test_resolve_plugin_variables_non_assoc;
+    ]);
+
+    (* mcp_helpers.ml — classify_http_error edges *)
+    ("classify_http_error w4", [
+      test_case "429 float" `Quick test_classify_429_with_float;
+      test_case "400" `Quick test_classify_400;
+      test_case "301" `Quick test_classify_301;
+    ]);
+
+    (* mcp_helpers.ml — resolve_variables edges *)
+    ("resolve_variables w4", [
+      test_case "empty valuesByMode" `Quick test_resolve_variables_empty_values_by_mode;
+      test_case "non-assoc variables" `Quick test_resolve_variables_non_assoc_variables;
+    ]);
+
+    (* mcp_helpers.ml — process_json_string *)
+    ("process_json_string w4", [
+      test_case "pixel format" `Quick test_process_json_pixel;
+      test_case "accuracy format" `Quick test_process_json_accuracy;
+    ]);
+
+    (* mcp_helpers.ml — make_error_json *)
+    ("make_error_json w4", [
+      test_case "empty debug_info" `Quick test_make_error_json_empty_debug;
+    ]);
+
+    (* mcp_helpers.ml — other exported *)
+    ("eio_context", [
+      test_case "get none" `Quick test_get_eio_context_none;
+    ]);
+    ("member w4", [
+      test_case "found" `Quick test_member_found;
+      test_case "missing" `Quick test_member_missing;
+      test_case "non-assoc" `Quick test_member_non_assoc;
+    ]);
+
+    (* figma_effects.ml *)
+    ("effects create_mock_store", [
+      test_case "fresh" `Quick test_effects_create_mock_store_fresh;
+    ]);
+    ("effects run_with_mock", [
+      test_case "exception" `Quick test_run_with_mock_exception;
+      test_case "pure" `Quick test_run_with_mock_pure;
+      test_case "me set/unset" `Quick test_run_with_mock_me_set_unset;
+      test_case "multi effects" `Quick test_run_with_mock_multi_effects;
+    ]);
+    ("neo4j statement w4", [
+      test_case "complex params" `Quick test_neo4j_statement_complex_params;
+    ]);
+    ("parse_neo4j w4", [
+      test_case "partial error" `Quick test_parse_neo4j_partial_error;
+      test_case "only message" `Quick test_parse_neo4j_only_message;
+      test_case "no results" `Quick test_parse_neo4j_no_results;
+    ]);
+
+    (* server_metrics.ml *)
+    ("prom_metric", [
+      test_case "basic" `Quick test_prom_metric_basic;
+      test_case "empty labels" `Quick test_prom_metric_empty_labels;
+      test_case "float value" `Quick test_prom_metric_float_value;
+    ]);
+    ("snapshot", [
+      test_case "initial" `Quick test_snapshot_initial;
+    ]);
+    ("to_json", [
+      test_case "structure" `Quick test_to_json;
+    ]);
+    ("to_prometheus_text", [
+      test_case "format" `Quick test_to_prometheus_text;
+    ]);
+    ("sse", [
+      test_case "open/close" `Quick test_sse_open_close;
+      test_case "close floor" `Quick test_sse_close_floor;
+    ]);
+    ("record_untracked w4", [
+      test_case "2xx" `Quick test_record_untracked_2xx;
+      test_case "3xx" `Quick test_record_untracked_3xx;
+      test_case "no bytes" `Quick test_record_untracked_no_bytes;
+      test_case "with bytes" `Quick test_record_untracked_with_bytes;
+      test_case "sequence" `Quick test_record_untracked_sequence;
+    ]);
+    ("latency", [
+      test_case "empty snapshot" `Quick test_latency_empty_snapshot;
+    ]);
+  ]

--- a/test/test_plugin_w4.ml
+++ b/test/test_plugin_w4.ml
@@ -1,0 +1,659 @@
+(** Coverage Wave 4: figma_plugin_bridge.ml, figma_plugin_features.ml,
+    mcp_plugin_handlers.ml — uncovered pure branches.
+
+    Targets:
+      - figma_plugin_bridge: channel lifecycle, payload check, store/take,
+        poll_commands, poll_events, publish_event, cleanup_inactive
+      - figma_plugin_features: CSS keyframe branches, Swift modifier branches,
+        easing functions, accessibility (link/input/nav), webhook types,
+        safe_member_type/to_num/safe_num edge cases, animations_to_json,
+        accessibility_to_json
+      - mcp_plugin_handlers: handle_plugin_delete_nodes (missing/empty ids),
+        handle_plugin_subscribe_events (no channel, timeout=0) *)
+
+(* ============== Helpers ============== *)
+
+let str_contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl > hl then false
+  else
+    let rec loop i =
+      if i > hl - nl then false
+      else if String.sub haystack i nl = needle then true
+      else loop (i + 1)
+    in loop 0
+
+(* ============== 1. figma_plugin_bridge — channel lifecycle ============== *)
+
+let test_bridge_register_channel () =
+  let id = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-ch1" () in
+  Alcotest.(check string) "explicit id" "test-w4-ch1" id;
+  let channels = Figma_plugin_bridge.list_channels () in
+  Alcotest.(check bool) "has channel" true (List.mem "test-w4-ch1" channels)
+
+let test_bridge_register_channel_auto () =
+  let id = Figma_plugin_bridge.register_channel () in
+  Alcotest.(check bool) "auto id starts with ch-" true
+    (String.length id > 3 && String.sub id 0 3 = "ch-")
+
+let test_bridge_default_channel () =
+  let _ = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-default" () in
+  let d = Figma_plugin_bridge.get_default_channel () in
+  Alcotest.(check bool) "has default" true (d <> None);
+  Figma_plugin_bridge.set_default_channel "test-w4-override";
+  let d2 = Figma_plugin_bridge.get_default_channel () in
+  Alcotest.(check (option string)) "overridden" (Some "test-w4-override") d2
+
+let test_bridge_list_channel_stats () =
+  let _ = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-stats" () in
+  let stats = Figma_plugin_bridge.list_channel_stats () in
+  let found = List.exists (fun (s : Figma_plugin_bridge.channel_stats) ->
+    s.id = "test-w4-stats"
+  ) stats in
+  Alcotest.(check bool) "stats has channel" true found
+
+(* ============== 2. figma_plugin_bridge — enqueue/poll/store/take ============== *)
+
+let test_bridge_enqueue_poll () =
+  let ch = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-eq" () in
+  let _ = Figma_plugin_bridge.enqueue_command
+    ~channel_id:ch ~name:"test_cmd" ~payload:(`String "hello") in
+  let cmds = Figma_plugin_bridge.poll_commands ~channel_id:ch ~max:10 in
+  Alcotest.(check int) "one command" 1 (List.length cmds);
+  let cmd = List.hd cmds in
+  Alcotest.(check string) "cmd name" "test_cmd" cmd.name
+
+let test_bridge_store_take_result () =
+  let ch = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-st" () in
+  Figma_plugin_bridge.store_result ~channel_id:ch ~command_id:"cmd-1"
+    ~ok:true ~payload:(`String "result");
+  let r = Figma_plugin_bridge.take_result ~channel_id:ch ~command_id:"cmd-1" in
+  Alcotest.(check bool) "result found" true (r <> None);
+  let result = Option.get r in
+  Alcotest.(check bool) "ok" true result.ok;
+  (* Take again should be None *)
+  let r2 = Figma_plugin_bridge.take_result ~channel_id:ch ~command_id:"cmd-1" in
+  Alcotest.(check bool) "consumed" true (r2 = None)
+
+let test_bridge_take_nonexistent_channel () =
+  let r = Figma_plugin_bridge.take_result
+    ~channel_id:"nonexistent-w4" ~command_id:"cmd-x" in
+  Alcotest.(check bool) "None for missing channel" true (r = None)
+
+let test_bridge_poll_commands_empty () =
+  let ch = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-pempty" () in
+  let cmds = Figma_plugin_bridge.poll_commands ~channel_id:ch ~max:10 in
+  Alcotest.(check int) "empty" 0 (List.length cmds)
+
+(* ============== 3. figma_plugin_bridge — events ============== *)
+
+let test_bridge_publish_poll_events () =
+  let ch = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-ev" () in
+  Figma_plugin_bridge.publish_event ~channel_id:ch
+    ~event_type:"selection_change" ~payload:(`String "sel1");
+  Figma_plugin_bridge.publish_event ~channel_id:ch
+    ~event_type:"document_change" ~payload:(`String "doc1");
+  let evts = Figma_plugin_bridge.poll_events ~channel_id:ch ~max:10 in
+  Alcotest.(check int) "two events" 2 (List.length evts);
+  let first = List.hd evts in
+  Alcotest.(check string) "event type" "selection_change" first.event_type
+
+let test_bridge_poll_events_nonexistent () =
+  let evts = Figma_plugin_bridge.poll_events ~channel_id:"nonexist-w4" ~max:10 in
+  Alcotest.(check int) "empty for missing" 0 (List.length evts)
+
+let test_bridge_publish_no_channel () =
+  (* publish_event to a non-existent channel should not crash *)
+  Figma_plugin_bridge.publish_event ~channel_id:"ghost-w4"
+    ~event_type:"test" ~payload:`Null;
+  Alcotest.(check bool) "no crash" true true
+
+(* ============== 4. figma_plugin_bridge — payload limit ============== *)
+
+let test_bridge_check_payload_limit () =
+  (* Small payload should pass *)
+  let small = `String "hi" in
+  let r = Figma_plugin_bridge.check_payload_limit small in
+  (match r with
+   | Ok () -> ()
+   | Error _ -> Alcotest.fail "small payload should pass")
+
+(* ============== 5. figma_plugin_bridge — cleanup_inactive ============== *)
+
+let test_bridge_cleanup_inactive () =
+  (* cleanup_inactive with a large ttl should not remove active channels *)
+  let _ = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-cleanup" () in
+  Figma_plugin_bridge.cleanup_inactive ~ttl_seconds:99999.0;
+  let channels = Figma_plugin_bridge.list_channels () in
+  Alcotest.(check bool) "still present" true (List.mem "test-w4-cleanup" channels)
+
+(* ============== 6. figma_plugin_bridge — event waiters ============== *)
+
+let test_bridge_event_waiter_register_unregister () =
+  let ch = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-ew" () in
+  let wid = Figma_plugin_bridge.register_event_waiter ~channel_id:ch
+    ~notify:(fun () -> ()) in
+  Alcotest.(check bool) "waiter id > 0" true (wid > 0);
+  Figma_plugin_bridge.unregister_event_waiter ~channel_id:ch ~waiter_id:wid;
+  (* No crash after unregister *)
+  Alcotest.(check bool) "unregistered ok" true true
+
+let test_bridge_unregister_event_waiter_missing_channel () =
+  Figma_plugin_bridge.unregister_event_waiter
+    ~channel_id:"no-such-channel-w4" ~waiter_id:999;
+  Alcotest.(check bool) "no crash" true true
+
+(* ============== 7. figma_plugin_features — safe helpers ============== *)
+
+let test_safe_member_type_null () =
+  let r = Figma_plugin_features.safe_member_type `Null in
+  Alcotest.(check string) "null → empty" "" r
+
+let test_safe_member_type_obj () =
+  let obj = `Assoc [("type", `String "FRAME")] in
+  let r = Figma_plugin_features.safe_member_type obj in
+  Alcotest.(check string) "has type" "FRAME" r
+
+let test_to_num_float () =
+  Alcotest.(check (float 0.01)) "float" 3.14 (Figma_plugin_features.to_num (`Float 3.14))
+
+let test_to_num_int () =
+  Alcotest.(check (float 0.01)) "int" 42.0 (Figma_plugin_features.to_num (`Int 42))
+
+let test_to_num_other () =
+  Alcotest.(check (float 0.01)) "other" 0.0 (Figma_plugin_features.to_num (`String "x"))
+
+let test_safe_num_null () =
+  Alcotest.(check (float 0.01)) "null → 0" 0.0 (Figma_plugin_features.safe_num "x" `Null)
+
+let test_safe_num_present () =
+  let obj = `Assoc [("val", `Float 5.5)] in
+  Alcotest.(check (float 0.01)) "present" 5.5 (Figma_plugin_features.safe_num "val" obj)
+
+let test_contains_word_found () =
+  Alcotest.(check bool) "found" true (Figma_plugin_features.contains_word "hello world" "world")
+
+let test_contains_word_not_found () =
+  Alcotest.(check bool) "not found" false (Figma_plugin_features.contains_word "hello" "world")
+
+(* ============== 8. figma_plugin_features — CSS keyframes branches ============== *)
+
+let test_css_keyframes_dissolve () =
+  let kf = Figma_plugin_features.generate_css_keyframes "DISSOLVE" 0.5 0.0 in
+  Alcotest.(check bool) "has opacity" true (str_contains ~needle:"opacity" kf)
+
+let test_css_keyframes_move_in () =
+  let kf = Figma_plugin_features.generate_css_keyframes "MOVE_IN" 0.0 0.0 in
+  Alcotest.(check bool) "has translateX" true (str_contains ~needle:"translateX" kf)
+
+let test_css_keyframes_slide_in () =
+  let kf = Figma_plugin_features.generate_css_keyframes "SLIDE_IN" 0.0 0.0 in
+  Alcotest.(check bool) "has translateX" true (str_contains ~needle:"translateX" kf)
+
+let test_css_keyframes_move_out () =
+  let kf = Figma_plugin_features.generate_css_keyframes "MOVE_OUT" 0.0 0.0 in
+  Alcotest.(check bool) "has 100%" true (str_contains ~needle:"100%" kf)
+
+let test_css_keyframes_slide_out () =
+  let kf = Figma_plugin_features.generate_css_keyframes "SLIDE_OUT" 0.0 0.0 in
+  Alcotest.(check bool) "has 100%" true (str_contains ~needle:"100%" kf)
+
+let test_css_keyframes_push () =
+  let kf = Figma_plugin_features.generate_css_keyframes "PUSH" 0.0 0.0 in
+  Alcotest.(check bool) "has scale" true (str_contains ~needle:"scale" kf)
+
+let test_css_keyframes_smart_animate () =
+  let kf = Figma_plugin_features.generate_css_keyframes "SMART_ANIMATE" 0.5 45.0 in
+  Alcotest.(check bool) "has translateY" true (str_contains ~needle:"translateY" kf);
+  Alcotest.(check bool) "has rotate" true (str_contains ~needle:"rotate" kf)
+
+let test_css_keyframes_smart_animate_no_rotation () =
+  let kf = Figma_plugin_features.generate_css_keyframes "SMART_ANIMATE" 0.5 0.0 in
+  Alcotest.(check bool) "has translateY" true (str_contains ~needle:"translateY" kf);
+  Alcotest.(check bool) "no rotate" false (str_contains ~needle:"rotate" kf)
+
+let test_css_keyframes_unknown () =
+  let kf = Figma_plugin_features.generate_css_keyframes "UNKNOWN" 0.5 0.0 in
+  Alcotest.(check bool) "has opacity" true (str_contains ~needle:"opacity" kf)
+
+(* ============== 9. figma_plugin_features — CSS easing branches ============== *)
+
+let test_css_easing_ease_in () =
+  Alcotest.(check string) "ease-in" "ease-in"
+    (Figma_plugin_features.css_easing_of_figma "EASE_IN")
+
+let test_css_easing_ease_out () =
+  Alcotest.(check string) "ease-out" "ease-out"
+    (Figma_plugin_features.css_easing_of_figma "EASE_OUT")
+
+let test_css_easing_ease_in_out () =
+  Alcotest.(check string) "ease-in-out" "ease-in-out"
+    (Figma_plugin_features.css_easing_of_figma "EASE_IN_AND_OUT")
+
+let test_css_easing_linear () =
+  Alcotest.(check string) "linear" "linear"
+    (Figma_plugin_features.css_easing_of_figma "LINEAR")
+
+let test_css_easing_custom_bezier () =
+  let r = Figma_plugin_features.css_easing_of_figma "CUSTOM_BEZIER" in
+  Alcotest.(check bool) "has cubic-bezier" true (str_contains ~needle:"cubic-bezier" r)
+
+let test_css_easing_unknown () =
+  Alcotest.(check string) "default" "ease-out"
+    (Figma_plugin_features.css_easing_of_figma "WHATEVER")
+
+(* ============== 10. figma_plugin_features — Swift easing branches ============== *)
+
+let test_swift_easing_ease_in () =
+  Alcotest.(check string) ".easeIn" ".easeIn"
+    (Figma_plugin_features.swift_easing_of_figma "EASE_IN")
+
+let test_swift_easing_ease_out () =
+  Alcotest.(check string) ".easeOut" ".easeOut"
+    (Figma_plugin_features.swift_easing_of_figma "EASE_OUT")
+
+let test_swift_easing_ease_in_out () =
+  Alcotest.(check string) ".easeInOut" ".easeInOut"
+    (Figma_plugin_features.swift_easing_of_figma "EASE_IN_AND_OUT")
+
+let test_swift_easing_linear () =
+  Alcotest.(check string) ".linear" ".linear"
+    (Figma_plugin_features.swift_easing_of_figma "LINEAR")
+
+let test_swift_easing_custom_bezier () =
+  let r = Figma_plugin_features.swift_easing_of_figma "CUSTOM_BEZIER" in
+  Alcotest.(check bool) "has timingCurve" true (str_contains ~needle:"timingCurve" r)
+
+let test_swift_easing_unknown () =
+  Alcotest.(check string) "default" ".easeOut"
+    (Figma_plugin_features.swift_easing_of_figma "WHATEVER")
+
+(* ============== 11. figma_plugin_features — Swift modifiers branches ============== *)
+
+let test_swift_mod_dissolve () =
+  let r = Figma_plugin_features.generate_swift_modifiers "DISSOLVE" 0.5 0.0 in
+  Alcotest.(check bool) "has opacity" true (str_contains ~needle:".opacity" r)
+
+let test_swift_mod_move_in () =
+  let r = Figma_plugin_features.generate_swift_modifiers "MOVE_IN" 0.0 0.0 in
+  Alcotest.(check bool) "has offset" true (str_contains ~needle:".offset" r)
+
+let test_swift_mod_slide_in () =
+  let r = Figma_plugin_features.generate_swift_modifiers "SLIDE_IN" 0.0 0.0 in
+  Alcotest.(check bool) "has offset" true (str_contains ~needle:".offset" r)
+
+let test_swift_mod_move_out () =
+  let r = Figma_plugin_features.generate_swift_modifiers "MOVE_OUT" 0.0 0.0 in
+  Alcotest.(check bool) "has offset" true (str_contains ~needle:".offset" r)
+
+let test_swift_mod_slide_out () =
+  let r = Figma_plugin_features.generate_swift_modifiers "SLIDE_OUT" 0.0 0.0 in
+  Alcotest.(check bool) "has offset" true (str_contains ~needle:".offset" r)
+
+let test_swift_mod_push () =
+  let r = Figma_plugin_features.generate_swift_modifiers "PUSH" 0.0 0.0 in
+  Alcotest.(check bool) "has scaleEffect" true (str_contains ~needle:".scaleEffect" r)
+
+let test_swift_mod_smart_animate () =
+  let r = Figma_plugin_features.generate_swift_modifiers "SMART_ANIMATE" 0.5 45.0 in
+  Alcotest.(check bool) "has offset" true (str_contains ~needle:".offset" r);
+  Alcotest.(check bool) "has rotation" true (str_contains ~needle:"rotationEffect" r)
+
+let test_swift_mod_smart_animate_no_rotation () =
+  let r = Figma_plugin_features.generate_swift_modifiers "SMART_ANIMATE" 0.5 0.0 in
+  Alcotest.(check bool) "has offset" true (str_contains ~needle:".offset" r);
+  Alcotest.(check bool) "no rotation" false (str_contains ~needle:"rotationEffect" r)
+
+let test_swift_mod_unknown () =
+  let r = Figma_plugin_features.generate_swift_modifiers "UNKNOWN" 0.5 0.0 in
+  Alcotest.(check bool) "has opacity" true (str_contains ~needle:".opacity" r)
+
+(* ============== 12. figma_plugin_features — accessibility branches ============== *)
+
+let test_accessibility_link () =
+  let node = `Assoc [
+    ("name", `String "Learn More Link"); ("type", `String "FRAME");
+  ] in
+  let (attrs, _) = Figma_plugin_features.analyze_accessibility node in
+  let has_link = List.exists (fun (a : Figma_plugin_features.aria_attr) ->
+    a.role = "link"
+  ) attrs in
+  Alcotest.(check bool) "has link role" true has_link
+
+let test_accessibility_input () =
+  let node = `Assoc [
+    ("name", `String "Email Input Field"); ("type", `String "FRAME");
+  ] in
+  let (attrs, suggestions) = Figma_plugin_features.analyze_accessibility node in
+  let has_textbox = List.exists (fun (a : Figma_plugin_features.aria_attr) ->
+    a.role = "textbox"
+  ) attrs in
+  Alcotest.(check bool) "has textbox role" true has_textbox;
+  Alcotest.(check bool) "has suggestion" true (List.length suggestions > 0)
+
+let test_accessibility_nav () =
+  let node = `Assoc [
+    ("name", `String "Main Nav Menu"); ("type", `String "FRAME");
+  ] in
+  let (attrs, _) = Figma_plugin_features.analyze_accessibility node in
+  let has_nav = List.exists (fun (a : Figma_plugin_features.aria_attr) ->
+    a.role = "navigation"
+  ) attrs in
+  Alcotest.(check bool) "has nav role" true has_nav
+
+let test_accessibility_to_json () =
+  let attrs = [Figma_plugin_features.{
+    element = "Btn"; role = "button";
+    attributes = [("aria-label", `String "Click")];
+  }] in
+  let suggestions = ["Add label"] in
+  let json = Figma_plugin_features.accessibility_to_json (attrs, suggestions) in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "has ariaAttributes" true (str_contains ~needle:"ariaAttributes" s);
+  Alcotest.(check bool) "has suggestions" true (str_contains ~needle:"suggestions" s)
+
+(* ============== 13. figma_plugin_features — animations_to_json ============== *)
+
+let test_animations_to_json_empty () =
+  let json = Figma_plugin_features.animations_to_json [] in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "has animations" true (str_contains ~needle:"animations" s);
+  Alcotest.(check bool) "has css" true (str_contains ~needle:"css" s);
+  Alcotest.(check bool) "has swiftui" true (str_contains ~needle:"swiftui" s)
+
+let test_animations_to_json_with_anim () =
+  let anim = Figma_plugin_features.{
+    element = "Box";
+    trigger = "ON_CLICK";
+    trans_type = "DISSOLVE";
+    duration = 0.3;
+    easing = "EASE_OUT";
+    properties = [("opacity", 0.5)];
+  } in
+  let json = Figma_plugin_features.animations_to_json [anim] in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "has element" true (str_contains ~needle:"Box" s)
+
+(* ============== 14. figma_plugin_features — webhook branches ============== *)
+
+let test_webhook_file_version_update () =
+  let json = Figma_plugin_features.process_webhook
+    "FILE_VERSION_UPDATE" "key1" "Design" "2026-01-01T00:00:00Z" in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "check_version_diff" true
+    (str_contains ~needle:"check_version_diff" s)
+
+let test_webhook_file_comment () =
+  let json = Figma_plugin_features.process_webhook
+    "FILE_COMMENT" "key2" "Design" "2026-01-01T00:00:00Z" in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "review_comment" true
+    (str_contains ~needle:"review_comment" s)
+
+let test_webhook_unknown () =
+  let json = Figma_plugin_features.process_webhook
+    "CUSTOM_EVENT" "key3" "Design" "2026-01-01T00:00:00Z" in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "log_event" true
+    (str_contains ~needle:"log_event" s)
+
+(* ============== 15. figma_plugin_features — animation_to_css branches ============== *)
+
+let test_animation_to_css_move_in () =
+  let anim = Figma_plugin_features.{
+    element = "Panel"; trigger = "ON_CLICK";
+    trans_type = "MOVE_IN"; duration = 0.4; easing = "LINEAR";
+    properties = [];
+  } in
+  let css = Figma_plugin_features.animation_to_css 0 anim in
+  Alcotest.(check bool) "has keyframes" true (str_contains ~needle:"@keyframes" css);
+  Alcotest.(check bool) "has linear" true (str_contains ~needle:"linear" css)
+
+let test_animation_to_css_smart_animate_with_rotation () =
+  let anim = Figma_plugin_features.{
+    element = "Spinner"; trigger = "state_change";
+    trans_type = "SMART_ANIMATE"; duration = 0.0; (* triggers default 0.3 *)
+    easing = "CUSTOM_BEZIER";
+    properties = [("opacity", 0.8); ("rotation", 90.0)];
+  } in
+  let css = Figma_plugin_features.animation_to_css 0 anim in
+  Alcotest.(check bool) "has rotate" true (str_contains ~needle:"rotate" css);
+  Alcotest.(check bool) "has cubic-bezier" true (str_contains ~needle:"cubic-bezier" css)
+
+(* ============== 16. figma_plugin_features — animation_to_swiftui branches ============== *)
+
+let test_animation_to_swiftui_push () =
+  let anim = Figma_plugin_features.{
+    element = "Screen"; trigger = "ON_CLICK";
+    trans_type = "PUSH"; duration = 0.5; easing = "EASE_IN";
+    properties = [];
+  } in
+  let swift = Figma_plugin_features.animation_to_swiftui 0 anim in
+  Alcotest.(check bool) "has animation" true (str_contains ~needle:".animation" swift);
+  Alcotest.(check bool) "has scaleEffect" true (str_contains ~needle:"scaleEffect" swift)
+
+let test_animation_to_swiftui_smart_animate_rotation () =
+  let anim = Figma_plugin_features.{
+    element = "Dial"; trigger = "state_change";
+    trans_type = "SMART_ANIMATE"; duration = 0.0;
+    easing = "EASE_IN_AND_OUT";
+    properties = [("opacity", 0.6); ("rotation", 180.0)];
+  } in
+  let swift = Figma_plugin_features.animation_to_swiftui 0 anim in
+  Alcotest.(check bool) "has rotationEffect" true (str_contains ~needle:"rotationEffect" swift)
+
+(* ============== 17. figma_plugin_features — variant edge case ============== *)
+
+let test_variant_empty_children () =
+  let node = `Assoc [
+    ("name", `String "Empty"); ("type", `String "COMPONENT_SET");
+    ("children", `List []);
+  ] in
+  let (variants, _props) = Figma_plugin_features.extract_variants node in
+  Alcotest.(check int) "no variants" 0 (List.length variants)
+
+let test_variant_no_children () =
+  let node = `Assoc [
+    ("name", `String "NoKids"); ("type", `String "COMPONENT_SET");
+  ] in
+  let (variants, _props) = Figma_plugin_features.extract_variants node in
+  Alcotest.(check int) "no variants" 0 (List.length variants)
+
+(* ============== 18. mcp_plugin_handlers — delete_nodes ============== *)
+
+let test_delete_nodes_missing_ids () =
+  let args = `Assoc [] in
+  (match Mcp_plugin_handlers.handle_plugin_delete_nodes args with
+   | Error e ->
+       Alcotest.(check bool) "has node_ids" true (str_contains ~needle:"node_ids" e)
+   | Ok _ -> Alcotest.fail "expected error for missing node_ids")
+
+let test_delete_nodes_non_array () =
+  (* Register a channel so resolve_channel_id succeeds *)
+  let _ = Figma_plugin_bridge.register_channel ~channel_id:"test-w4-del" () in
+  let args = `Assoc [
+    ("node_ids", `String "not-an-array");
+    ("channel_id", `String "test-w4-del");
+  ] in
+  (match Mcp_plugin_handlers.handle_plugin_delete_nodes args with
+   | Error e ->
+       Alcotest.(check bool) "has non-empty" true (str_contains ~needle:"non-empty" e)
+   | Ok _ -> Alcotest.fail "expected error for non-array node_ids")
+
+let test_delete_nodes_empty_array () =
+  let args = `Assoc [
+    ("node_ids", `List []);
+    ("channel_id", `String "test-w4-del");
+  ] in
+  (match Mcp_plugin_handlers.handle_plugin_delete_nodes args with
+   | Error e ->
+       Alcotest.(check bool) "has non-empty" true (str_contains ~needle:"non-empty" e)
+   | Ok _ -> Alcotest.fail "expected error for empty node_ids")
+
+(* ============== 19. mcp_plugin_handlers — subscribe_events ============== *)
+
+let test_subscribe_events_no_channel () =
+  (* Clear default so resolve_channel_id fails *)
+  Figma_plugin_bridge.set_default_channel "test-w4-sub";
+  let args = `Assoc [
+    ("channel_id", `String "test-w4-sub");
+    ("timeout_ms", `Int 0);
+  ] in
+  (match Mcp_plugin_handlers.handle_plugin_subscribe_events args with
+   | Ok json ->
+       let s = Yojson.Safe.to_string json in
+       Alcotest.(check bool) "has events" true (str_contains ~needle:"events" s)
+   | Error _ ->
+       (* also acceptable — depends on Eio context *)
+       ())
+
+(* ============== 20. figma_plugin_features — responsive CSS ============== *)
+
+let test_responsive_small () =
+  let json = Figma_plugin_features.generate_responsive_css "Tiny" 50 20 in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "has breakpoints" true (str_contains ~needle:"breakpoints" s)
+
+(* ============== Test Suite ============== *)
+
+let bridge_lifecycle_tests = [
+  ("register explicit", `Quick, test_bridge_register_channel);
+  ("register auto", `Quick, test_bridge_register_channel_auto);
+  ("default channel", `Quick, test_bridge_default_channel);
+  ("channel stats", `Quick, test_bridge_list_channel_stats);
+]
+
+let bridge_cmd_tests = [
+  ("enqueue + poll", `Quick, test_bridge_enqueue_poll);
+  ("store + take result", `Quick, test_bridge_store_take_result);
+  ("take nonexistent", `Quick, test_bridge_take_nonexistent_channel);
+  ("poll empty", `Quick, test_bridge_poll_commands_empty);
+]
+
+let bridge_event_tests = [
+  ("publish + poll events", `Quick, test_bridge_publish_poll_events);
+  ("poll events nonexistent", `Quick, test_bridge_poll_events_nonexistent);
+  ("publish no channel", `Quick, test_bridge_publish_no_channel);
+  ("event waiter lifecycle", `Quick, test_bridge_event_waiter_register_unregister);
+  ("unregister missing channel", `Quick, test_bridge_unregister_event_waiter_missing_channel);
+]
+
+let bridge_misc_tests = [
+  ("payload limit", `Quick, test_bridge_check_payload_limit);
+  ("cleanup inactive", `Quick, test_bridge_cleanup_inactive);
+]
+
+let features_helper_tests = [
+  ("safe_member_type null", `Quick, test_safe_member_type_null);
+  ("safe_member_type obj", `Quick, test_safe_member_type_obj);
+  ("to_num float", `Quick, test_to_num_float);
+  ("to_num int", `Quick, test_to_num_int);
+  ("to_num other", `Quick, test_to_num_other);
+  ("safe_num null", `Quick, test_safe_num_null);
+  ("safe_num present", `Quick, test_safe_num_present);
+  ("contains_word found", `Quick, test_contains_word_found);
+  ("contains_word not found", `Quick, test_contains_word_not_found);
+]
+
+let css_keyframe_tests = [
+  ("DISSOLVE", `Quick, test_css_keyframes_dissolve);
+  ("MOVE_IN", `Quick, test_css_keyframes_move_in);
+  ("SLIDE_IN", `Quick, test_css_keyframes_slide_in);
+  ("MOVE_OUT", `Quick, test_css_keyframes_move_out);
+  ("SLIDE_OUT", `Quick, test_css_keyframes_slide_out);
+  ("PUSH", `Quick, test_css_keyframes_push);
+  ("SMART_ANIMATE", `Quick, test_css_keyframes_smart_animate);
+  ("SMART_ANIMATE no rot", `Quick, test_css_keyframes_smart_animate_no_rotation);
+  ("unknown", `Quick, test_css_keyframes_unknown);
+]
+
+let css_easing_tests = [
+  ("EASE_IN", `Quick, test_css_easing_ease_in);
+  ("EASE_OUT", `Quick, test_css_easing_ease_out);
+  ("EASE_IN_AND_OUT", `Quick, test_css_easing_ease_in_out);
+  ("LINEAR", `Quick, test_css_easing_linear);
+  ("CUSTOM_BEZIER", `Quick, test_css_easing_custom_bezier);
+  ("unknown", `Quick, test_css_easing_unknown);
+]
+
+let swift_easing_tests = [
+  ("EASE_IN", `Quick, test_swift_easing_ease_in);
+  ("EASE_OUT", `Quick, test_swift_easing_ease_out);
+  ("EASE_IN_AND_OUT", `Quick, test_swift_easing_ease_in_out);
+  ("LINEAR", `Quick, test_swift_easing_linear);
+  ("CUSTOM_BEZIER", `Quick, test_swift_easing_custom_bezier);
+  ("unknown", `Quick, test_swift_easing_unknown);
+]
+
+let swift_mod_tests = [
+  ("DISSOLVE", `Quick, test_swift_mod_dissolve);
+  ("MOVE_IN", `Quick, test_swift_mod_move_in);
+  ("SLIDE_IN", `Quick, test_swift_mod_slide_in);
+  ("MOVE_OUT", `Quick, test_swift_mod_move_out);
+  ("SLIDE_OUT", `Quick, test_swift_mod_slide_out);
+  ("PUSH", `Quick, test_swift_mod_push);
+  ("SMART_ANIMATE", `Quick, test_swift_mod_smart_animate);
+  ("SMART_ANIMATE no rot", `Quick, test_swift_mod_smart_animate_no_rotation);
+  ("unknown", `Quick, test_swift_mod_unknown);
+]
+
+let accessibility_tests = [
+  ("link role", `Quick, test_accessibility_link);
+  ("input role", `Quick, test_accessibility_input);
+  ("nav role", `Quick, test_accessibility_nav);
+  ("to_json", `Quick, test_accessibility_to_json);
+]
+
+let animation_json_tests = [
+  ("empty", `Quick, test_animations_to_json_empty);
+  ("with anim", `Quick, test_animations_to_json_with_anim);
+]
+
+let webhook_tests = [
+  ("FILE_VERSION_UPDATE", `Quick, test_webhook_file_version_update);
+  ("FILE_COMMENT", `Quick, test_webhook_file_comment);
+  ("unknown event", `Quick, test_webhook_unknown);
+]
+
+let codegen_tests = [
+  ("css move_in", `Quick, test_animation_to_css_move_in);
+  ("css smart_animate rotation", `Quick, test_animation_to_css_smart_animate_with_rotation);
+  ("swiftui push", `Quick, test_animation_to_swiftui_push);
+  ("swiftui smart_animate rotation", `Quick, test_animation_to_swiftui_smart_animate_rotation);
+]
+
+let variant_tests = [
+  ("empty children", `Quick, test_variant_empty_children);
+  ("no children", `Quick, test_variant_no_children);
+]
+
+let handler_tests = [
+  ("delete_nodes missing", `Quick, test_delete_nodes_missing_ids);
+  ("delete_nodes non-array", `Quick, test_delete_nodes_non_array);
+  ("delete_nodes empty", `Quick, test_delete_nodes_empty_array);
+  ("subscribe_events timeout=0", `Quick, test_subscribe_events_no_channel);
+]
+
+let responsive_tests = [
+  ("small component", `Quick, test_responsive_small);
+]
+
+let () =
+  Alcotest.run "Plugin W4" [
+    ("bridge_lifecycle", bridge_lifecycle_tests);
+    ("bridge_commands", bridge_cmd_tests);
+    ("bridge_events", bridge_event_tests);
+    ("bridge_misc", bridge_misc_tests);
+    ("features_helpers", features_helper_tests);
+    ("css_keyframes", css_keyframe_tests);
+    ("css_easing", css_easing_tests);
+    ("swift_easing", swift_easing_tests);
+    ("swift_modifiers", swift_mod_tests);
+    ("accessibility", accessibility_tests);
+    ("animations_json", animation_json_tests);
+    ("webhook", webhook_tests);
+    ("codegen", codegen_tests);
+    ("variants", variant_tests);
+    ("handlers", handler_tests);
+    ("responsive", responsive_tests);
+  ]

--- a/test/test_verifiers_coverage_w4.ml
+++ b/test/test_verifiers_coverage_w4.ml
@@ -1,0 +1,1024 @@
+(** Coverage Wave 4: visual_verifier.ml + semantic_verifier.ml + figma_image_similarity.ml
+    Targets uncovered pure functions across all three verifier modules.
+    Goal: 85%+ coverage per module. *)
+
+let () =
+  Unix.putenv "FIGMA_TOKEN" "test-token-12345";
+  let open Alcotest in
+  let open Figma_types in
+
+  (* ====== Helper constructors (shared) ====== *)
+  let mk_bbox x y w h : bbox = { x; y; width = w; height = h } in
+  let mk_rgba r g b a : rgba = { r; g; b; a } in
+  let solid (c: rgba) : paint =
+    { paint_type = Solid; visible = true; opacity = 1.0;
+      color = Some c; gradient_stops = []; image_ref = None; scale_mode = None }
+  in
+  let invisible_solid (c: rgba) : paint =
+    { paint_type = Solid; visible = false; opacity = 1.0;
+      color = Some c; gradient_stops = []; image_ref = None; scale_mode = None }
+  in
+  let gradient_paint : paint =
+    { paint_type = GradientLinear; visible = true; opacity = 1.0;
+      color = None; gradient_stops = []; image_ref = None; scale_mode = None }
+  in
+
+  (* ====== SEMANTIC_VERIFIER tests ====== *)
+
+  (* -- normalize_text -- *)
+  let test_sv_normalize_text_simple () =
+    check string "trim" "hello world" (Semantic_verifier.normalize_text "  hello   world  ")
+  in
+  let test_sv_normalize_text_newlines () =
+    check string "newlines" "a b c" (Semantic_verifier.normalize_text "a\n\tb\r c")
+  in
+  let test_sv_normalize_text_empty () =
+    check string "empty" "" (Semantic_verifier.normalize_text "   ")
+  in
+
+  (* -- rgba_dist_rgb -- *)
+  let test_sv_rgba_dist_same () =
+    let c = mk_rgba 0.5 0.5 0.5 1.0 in
+    check (float 0.001) "same" 0.0 (Semantic_verifier.rgba_dist_rgb c c)
+  in
+  let test_sv_rgba_dist_different () =
+    let a = mk_rgba 1.0 0.0 0.0 1.0 in
+    let b = mk_rgba 0.0 1.0 0.0 1.0 in
+    let d = Semantic_verifier.rgba_dist_rgb a b in
+    check bool "positive" true (d > 0.0);
+    check (float 0.01) "sqrt2" (sqrt 2.0) d
+  in
+  let test_sv_rgba_dist_black_white () =
+    let a = mk_rgba 0.0 0.0 0.0 1.0 in
+    let b = mk_rgba 1.0 1.0 1.0 1.0 in
+    let d = Semantic_verifier.rgba_dist_rgb a b in
+    check (float 0.01) "sqrt3" (sqrt 3.0) d
+  in
+
+  (* -- bbox_area -- *)
+  let test_sv_bbox_area_normal () =
+    check (float 0.001) "area" 600.0 (Semantic_verifier.bbox_area (mk_bbox 0. 0. 30. 20.))
+  in
+  let test_sv_bbox_area_zero () =
+    check (float 0.001) "zero" 0.0 (Semantic_verifier.bbox_area (mk_bbox 10. 20. 0. 0.))
+  in
+  let test_sv_bbox_area_single_dim_zero () =
+    check (float 0.001) "single zero" 0.0 (Semantic_verifier.bbox_area (mk_bbox 0. 0. 100. 0.))
+  in
+
+  (* -- bbox_center -- *)
+  let test_sv_bbox_center () =
+    let cx, cy = Semantic_verifier.bbox_center (mk_bbox 10. 20. 100. 50.) in
+    check (float 0.001) "cx" 60.0 cx;
+    check (float 0.001) "cy" 45.0 cy
+  in
+  let test_sv_bbox_center_origin () =
+    let cx, cy = Semantic_verifier.bbox_center (mk_bbox 0. 0. 10. 10.) in
+    check (float 0.001) "cx" 5.0 cx;
+    check (float 0.001) "cy" 5.0 cy
+  in
+
+  (* -- bbox_delta -- *)
+  let test_sv_bbox_delta_identical () =
+    let b = mk_bbox 10. 20. 100. 50. in
+    let dx, dy, dw, dh = Semantic_verifier.bbox_delta ~expected:b ~actual:b in
+    check (float 0.001) "dx" 0.0 dx;
+    check (float 0.001) "dy" 0.0 dy;
+    check (float 0.001) "dw" 0.0 dw;
+    check (float 0.001) "dh" 0.0 dh
+  in
+  let test_sv_bbox_delta_shifted () =
+    let e = mk_bbox 10. 20. 100. 50. in
+    let a = mk_bbox 15. 25. 110. 55. in
+    let dx, dy, dw, dh = Semantic_verifier.bbox_delta ~expected:e ~actual:a in
+    check (float 0.001) "dx" 5.0 dx;
+    check (float 0.001) "dy" 5.0 dy;
+    check (float 0.001) "dw" 10.0 dw;
+    check (float 0.001) "dh" 5.0 dh
+  in
+
+  (* -- bbox_within -- *)
+  let test_sv_bbox_within_exact () =
+    let b = mk_bbox 10. 20. 100. 50. in
+    check bool "exact" true (Semantic_verifier.bbox_within ~tol_px:0.0 ~expected:b ~actual:b)
+  in
+  let test_sv_bbox_within_inside_tol () =
+    let e = mk_bbox 10. 20. 100. 50. in
+    let a = mk_bbox 12. 22. 100. 50. in
+    check bool "inside" true (Semantic_verifier.bbox_within ~tol_px:3.0 ~expected:e ~actual:a)
+  in
+  let test_sv_bbox_within_outside_tol () =
+    let e = mk_bbox 10. 20. 100. 50. in
+    let a = mk_bbox 20. 20. 100. 50. in
+    check bool "outside" false (Semantic_verifier.bbox_within ~tol_px:5.0 ~expected:e ~actual:a)
+  in
+
+  (* -- normalize_bbox -- *)
+  let test_sv_normalize_bbox () =
+    let origin = mk_bbox 100. 200. 0. 0. in
+    let b = mk_bbox 120. 240. 50. 30. in
+    let r = Semantic_verifier.normalize_bbox ~origin b in
+    check (float 0.001) "x" 20.0 r.x;
+    check (float 0.001) "y" 40.0 r.y;
+    check (float 0.001) "w" 50.0 r.width;
+    check (float 0.001) "h" 30.0 r.height
+  in
+
+  (* -- pick_root_bbox -- *)
+  let test_sv_pick_root_with_root () =
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 5. 10. 290. 180.; background = None; border_radius_px = None };
+      bg_nodes = []; text_nodes = [];
+    } in
+    let b = Semantic_verifier.pick_root_bbox metrics in
+    check (float 0.001) "x" 5.0 b.x;
+    check (float 0.001) "w" 290.0 b.width
+  in
+  let test_sv_pick_root_no_root () =
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = None; bg_nodes = []; text_nodes = [];
+    } in
+    let b = Semantic_verifier.pick_root_bbox metrics in
+    check (float 0.001) "x" 0.0 b.x;
+    check (float 0.001) "w" 300.0 b.width;
+    check (float 0.001) "h" 200.0 b.height
+  in
+
+  (* -- solid_color_of_paints -- *)
+  let test_sv_solid_color_found () =
+    let c = mk_rgba 1.0 0.0 0.0 1.0 in
+    match Semantic_verifier.solid_color_of_paints [solid c] with
+    | Some r -> check (float 0.001) "r" 1.0 r.r
+    | None -> fail "expected Some"
+  in
+  let test_sv_solid_color_empty () =
+    check bool "none" true (Semantic_verifier.solid_color_of_paints [] = None)
+  in
+  let test_sv_solid_color_invisible () =
+    let c = mk_rgba 1.0 0.0 0.0 1.0 in
+    check bool "invisible" true (Semantic_verifier.solid_color_of_paints [invisible_solid c] = None)
+  in
+  let test_sv_solid_color_gradient_then_solid () =
+    let c = mk_rgba 0.0 1.0 0.0 1.0 in
+    match Semantic_verifier.solid_color_of_paints [gradient_paint; solid c] with
+    | Some r -> check (float 0.001) "g" 1.0 r.g
+    | None -> fail "expected Some from second paint"
+  in
+
+  (* -- extract_expected_texts -- *)
+  let test_sv_extract_texts_basic () =
+    let typo = { default_typography with font_size = 16.0; font_weight = 400 } in
+    let root_bbox = mk_bbox 100. 200. 300. 200. in
+    let text_node : ui_node = { default_node with
+      id = "t1"; name = "T"; node_type = Text;
+      bbox = Some (mk_bbox 120. 240. 80. 20.);
+      characters = Some "Hello";
+      typography = Some typo;
+      fills = [solid (mk_rgba 0.0 0.0 0.0 1.0)];
+      children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some root_bbox; children = [text_node];
+    } in
+    let texts = Semantic_verifier.extract_expected_texts ~root_bbox root in
+    check int "count" 1 (List.length texts);
+    let t = List.hd texts in
+    check string "text" "Hello" t.text;
+    check (float 0.001) "rel_x" 20.0 t.bbox.x;
+    check (float 0.001) "rel_y" 40.0 t.bbox.y
+  in
+  let test_sv_extract_texts_empty_chars () =
+    let root_bbox = mk_bbox 0. 0. 100. 100. in
+    let text_node : ui_node = { default_node with
+      id = "t2"; name = "T"; node_type = Text;
+      bbox = Some (mk_bbox 10. 10. 50. 20.);
+      characters = Some "   ";
+      children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some root_bbox; children = [text_node];
+    } in
+    let texts = Semantic_verifier.extract_expected_texts ~root_bbox root in
+    check int "empty chars skipped" 0 (List.length texts)
+  in
+  let test_sv_extract_texts_no_bbox () =
+    let root_bbox = mk_bbox 0. 0. 100. 100. in
+    let text_node : ui_node = { default_node with
+      id = "t3"; name = "T"; node_type = Text;
+      bbox = None; characters = Some "No bbox";
+      children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some root_bbox; children = [text_node];
+    } in
+    let texts = Semantic_verifier.extract_expected_texts ~root_bbox root in
+    check int "no bbox skipped" 0 (List.length texts)
+  in
+
+  (* -- choose_best_text_candidate -- *)
+  let test_sv_choose_exact_match () =
+    let expected : Semantic_verifier.expected_text = {
+      text = "Hello"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = Some 16.0; font_weight = Some 400;
+      color = Some (mk_rgba 0.0 0.0 0.0 1.0);
+    } in
+    let cand : Html_metrics.text_node = {
+      text = "Hello"; bbox = mk_bbox 22. 42. 80. 20.;
+      font_size_px = Some 16.0; font_weight = Some 400;
+      font_family = None; color = Some (mk_rgba 0.0 0.0 0.0 1.0);
+    } in
+    let origin = mk_bbox 0. 0. 300. 200. in
+    match Semantic_verifier.choose_best_text_candidate ~expected ~origin [cand] with
+    | Some c -> check string "matched" "Hello" c.text
+    | None -> fail "expected match"
+  in
+  let test_sv_choose_no_match () =
+    let expected : Semantic_verifier.expected_text = {
+      text = "Hello"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None; color = None;
+    } in
+    let cand : Html_metrics.text_node = {
+      text = "Goodbye"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None;
+      font_family = None; color = None;
+    } in
+    let origin = mk_bbox 0. 0. 300. 200. in
+    check bool "none" true
+      (Semantic_verifier.choose_best_text_candidate ~expected ~origin [cand] = None)
+  in
+  let test_sv_choose_substring_match () =
+    let expected : Semantic_verifier.expected_text = {
+      text = "Hello World"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None; color = None;
+    } in
+    let cand : Html_metrics.text_node = {
+      text = "Say Hello World Please"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None;
+      font_family = None; color = None;
+    } in
+    let origin = mk_bbox 0. 0. 300. 200. in
+    match Semantic_verifier.choose_best_text_candidate ~expected ~origin [cand] with
+    | Some c -> check string "substring" "Say Hello World Please" c.text
+    | None -> fail "expected substring match"
+  in
+  let test_sv_choose_short_text_no_substring () =
+    (* text length <= 2 should not attempt substring match *)
+    let expected : Semantic_verifier.expected_text = {
+      text = "Hi"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None; color = None;
+    } in
+    let cand : Html_metrics.text_node = {
+      text = "This Hi is here"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None;
+      font_family = None; color = None;
+    } in
+    let origin = mk_bbox 0. 0. 300. 200. in
+    check bool "short no substring" true
+      (Semantic_verifier.choose_best_text_candidate ~expected ~origin [cand] = None)
+  in
+  let test_sv_choose_best_by_distance () =
+    let expected : Semantic_verifier.expected_text = {
+      text = "Hello"; bbox = mk_bbox 20. 40. 80. 20.;
+      font_size_px = None; font_weight = None; color = None;
+    } in
+    let far : Html_metrics.text_node = {
+      text = "Hello"; bbox = mk_bbox 200. 200. 80. 20.;
+      font_size_px = None; font_weight = None;
+      font_family = None; color = None;
+    } in
+    let near : Html_metrics.text_node = {
+      text = "Hello"; bbox = mk_bbox 22. 42. 80. 20.;
+      font_size_px = None; font_weight = None;
+      font_family = None; color = None;
+    } in
+    let origin = mk_bbox 0. 0. 300. 200. in
+    match Semantic_verifier.choose_best_text_candidate ~expected ~origin [far; near] with
+    | Some c -> check (float 0.001) "near x" 22.0 c.bbox.x
+    | None -> fail "expected near match"
+  in
+
+  (* -- verify edge cases -- *)
+  let test_sv_verify_no_bbox () =
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = None; children = [];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = None; bg_nodes = []; text_nodes = [];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> check bool "has error" true (String.length e > 0)
+    | Ok _ -> fail "expected error for missing bbox"
+  in
+  let test_sv_verify_root_size_mismatch () =
+    let bg = mk_rgba 1.0 1.0 1.0 1.0 in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some (mk_bbox 0. 0. 300. 200.);
+      fills = [solid bg]; children = [];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 500; viewport_height = 400;
+      root = Some { bbox = mk_bbox 0. 0. 500. 400.; background = Some bg; border_radius_px = Some 0. };
+      bg_nodes = []; text_nodes = [];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check bool "has root size mismatch" true
+          (List.exists (function Semantic_verifier.RootSizeMismatch _ -> true | _ -> false) r.mismatches)
+  in
+  let test_sv_verify_bg_mismatch () =
+    let e_bg = mk_rgba 1.0 0.0 0.0 1.0 in
+    let a_bg = mk_rgba 0.0 0.0 1.0 1.0 in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some (mk_bbox 0. 0. 300. 200.);
+      fills = [solid e_bg]; children = [];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 0. 0. 300. 200.; background = Some a_bg; border_radius_px = None };
+      bg_nodes = []; text_nodes = [];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check bool "bg mismatch" true
+          (List.exists (function Semantic_verifier.RootBackgroundMismatch _ -> true | _ -> false) r.mismatches)
+  in
+  let test_sv_verify_border_radius_mismatch () =
+    let bg = mk_rgba 1.0 1.0 1.0 1.0 in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some (mk_bbox 0. 0. 300. 200.);
+      fills = [solid bg]; border_radius = 20.0; children = [];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 0. 0. 300. 200.; background = Some bg; border_radius_px = Some 2.0 };
+      bg_nodes = []; text_nodes = [];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check bool "radius mismatch" true
+          (List.exists (function Semantic_verifier.RootBorderRadiusMismatch _ -> true | _ -> false) r.mismatches)
+  in
+  let test_sv_verify_font_size_mismatch () =
+    let bg = mk_rgba 1.0 1.0 1.0 1.0 in
+    let text_color = mk_rgba 0.0 0.0 0.0 1.0 in
+    let root_abs = mk_bbox 0. 0. 300. 200. in
+    let text_abs = mk_bbox 20. 40. 100. 20. in
+    let typo = { default_typography with font_size = 16.0; font_weight = 400 } in
+    let text_node : ui_node = { default_node with
+      id = "t"; name = "T"; node_type = Text;
+      bbox = Some text_abs; characters = Some "Hello";
+      typography = Some typo;
+      fills = [solid text_color]; children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some root_abs; fills = [solid bg]; children = [text_node];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 0. 0. 300. 200.; background = Some bg; border_radius_px = None };
+      bg_nodes = [];
+      text_nodes = [{ text = "Hello"; bbox = mk_bbox 20. 40. 100. 20.;
+                      font_size_px = Some 24.0; font_weight = Some 400;
+                      font_family = None; color = Some text_color }];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check bool "font size" true
+          (List.exists (function Semantic_verifier.TextFontSizeMismatch _ -> true | _ -> false) r.mismatches)
+  in
+  let test_sv_verify_font_weight_mismatch () =
+    let bg = mk_rgba 1.0 1.0 1.0 1.0 in
+    let text_color = mk_rgba 0.0 0.0 0.0 1.0 in
+    let typo = { default_typography with font_size = 16.0; font_weight = 400 } in
+    let text_node : ui_node = { default_node with
+      id = "t"; name = "T"; node_type = Text;
+      bbox = Some (mk_bbox 20. 40. 100. 20.); characters = Some "Hello";
+      typography = Some typo;
+      fills = [solid text_color]; children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some (mk_bbox 0. 0. 300. 200.);
+      fills = [solid bg]; children = [text_node];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 0. 0. 300. 200.; background = Some bg; border_radius_px = None };
+      bg_nodes = [];
+      text_nodes = [{ text = "Hello"; bbox = mk_bbox 20. 40. 100. 20.;
+                      font_size_px = Some 16.0; font_weight = Some 800;
+                      font_family = None; color = Some text_color }];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check bool "font weight" true
+          (List.exists (function Semantic_verifier.TextFontWeightMismatch _ -> true | _ -> false) r.mismatches)
+  in
+  let test_sv_verify_text_color_mismatch () =
+    let bg = mk_rgba 1.0 1.0 1.0 1.0 in
+    let e_color = mk_rgba 1.0 0.0 0.0 1.0 in
+    let a_color = mk_rgba 0.0 0.0 1.0 1.0 in
+    let typo = { default_typography with font_size = 16.0; font_weight = 400 } in
+    let text_node : ui_node = { default_node with
+      id = "t"; name = "T"; node_type = Text;
+      bbox = Some (mk_bbox 20. 40. 100. 20.); characters = Some "Hello";
+      typography = Some typo;
+      fills = [solid e_color]; children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some (mk_bbox 0. 0. 300. 200.);
+      fills = [solid bg]; children = [text_node];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 0. 0. 300. 200.; background = Some bg; border_radius_px = None };
+      bg_nodes = [];
+      text_nodes = [{ text = "Hello"; bbox = mk_bbox 20. 40. 100. 20.;
+                      font_size_px = Some 16.0; font_weight = Some 400;
+                      font_family = None; color = Some a_color }];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check bool "text color" true
+          (List.exists (function Semantic_verifier.TextColorMismatch _ -> true | _ -> false) r.mismatches)
+  in
+  let test_sv_verify_score_calculation () =
+    (* 1 MissingText => score = 1.0 - 0.20 = 0.80 *)
+    let bg = mk_rgba 1.0 1.0 1.0 1.0 in
+    let typo = { default_typography with font_size = 16.0; font_weight = 400 } in
+    let text_node : ui_node = { default_node with
+      id = "t"; name = "T"; node_type = Text;
+      bbox = Some (mk_bbox 20. 40. 100. 20.); characters = Some "Missing";
+      typography = Some typo;
+      fills = [solid (mk_rgba 0. 0. 0. 1.)]; children = [];
+    } in
+    let root : ui_node = { default_node with
+      id = "root"; name = "Root"; node_type = Frame;
+      bbox = Some (mk_bbox 0. 0. 300. 200.);
+      fills = [solid bg]; children = [text_node];
+    } in
+    let metrics : Html_metrics.t = {
+      viewport_width = 300; viewport_height = 200;
+      root = Some { bbox = mk_bbox 0. 0. 300. 200.; background = Some bg; border_radius_px = None };
+      bg_nodes = []; text_nodes = [];
+    } in
+    match Semantic_verifier.verify ~dsl_node:root ~html:metrics () with
+    | Error e -> fail e
+    | Ok r ->
+        check (float 0.01) "score" 0.80 r.score;
+        check bool "not passed" false r.passed
+  in
+
+  (* -- mismatch_to_json (all 8 variants) -- *)
+  let test_sv_mismatch_json_root_size () =
+    let j = Semantic_verifier.mismatch_to_json
+      (RootSizeMismatch { expected_w=300.; expected_h=200.; actual_w=310.; actual_h=210.; dw=10.; dh=10. }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "root_size" t
+  in
+  let test_sv_mismatch_json_root_bg () =
+    let j = Semantic_verifier.mismatch_to_json
+      (RootBackgroundMismatch { expected = mk_rgba 1. 0. 0. 1.; actual = mk_rgba 0. 1. 0. 1.; dist = 1.41 }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "root_background" t
+  in
+  let test_sv_mismatch_json_root_radius () =
+    let j = Semantic_verifier.mismatch_to_json
+      (RootBorderRadiusMismatch { expected_px = 8.0; actual_px = 12.0; delta_px = 4.0 }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "root_border_radius" t
+  in
+  let test_sv_mismatch_json_missing_text () =
+    let j = Semantic_verifier.mismatch_to_json (MissingText { text = "Hello" }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "missing_text" t
+  in
+  let test_sv_mismatch_json_text_bbox () =
+    let j = Semantic_verifier.mismatch_to_json
+      (TextBBoxMismatch { text = "Hi"; expected = mk_bbox 0. 0. 50. 20.; actual = mk_bbox 10. 10. 50. 20.;
+                          dx = 10.; dy = 10.; dw = 0.; dh = 0. }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "text_bbox" t
+  in
+  let test_sv_mismatch_json_font_size () =
+    let j = Semantic_verifier.mismatch_to_json
+      (TextFontSizeMismatch { text = "Hi"; expected_px = 16.0; actual_px = 24.0; delta_px = 8.0 }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "text_font_size" t
+  in
+  let test_sv_mismatch_json_font_weight () =
+    let j = Semantic_verifier.mismatch_to_json
+      (TextFontWeightMismatch { text = "Hi"; expected = 400; actual = 700; delta = 300 }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "text_font_weight" t
+  in
+  let test_sv_mismatch_json_text_color () =
+    let j = Semantic_verifier.mismatch_to_json
+      (TextColorMismatch { text = "Hi"; expected = mk_rgba 1. 0. 0. 1.; actual = mk_rgba 0. 1. 0. 1.; dist = 1.41 }) in
+    let t = Yojson.Safe.Util.(j |> member "type" |> to_string) in
+    check string "type" "text_color" t
+  in
+
+  (* -- bbox_to_json, rgba_to_json -- *)
+  let test_sv_bbox_to_json () =
+    let j = Semantic_verifier.bbox_to_json (mk_bbox 10. 20. 30. 40.) in
+    let x = Yojson.Safe.Util.(j |> member "x" |> to_float) in
+    check (float 0.001) "x" 10.0 x
+  in
+  let test_sv_rgba_to_json () =
+    let j = Semantic_verifier.rgba_to_json (mk_rgba 0.5 0.6 0.7 0.8) in
+    let r = Yojson.Safe.Util.(j |> member "r" |> to_float) in
+    check (float 0.001) "r" 0.5 r
+  in
+
+  (* -- result_to_json -- *)
+  let test_sv_result_to_json () =
+    let r : Semantic_verifier.t = {
+      passed = true; score = 0.95;
+      root_expected = mk_bbox 0. 0. 300. 200.;
+      root_actual = mk_bbox 0. 0. 300. 200.;
+      total_texts = 1; matched_texts = 1; mismatches = [];
+    } in
+    let j = Semantic_verifier.result_to_json r in
+    let p = Yojson.Safe.Util.(j |> member "passed" |> to_bool) in
+    check bool "passed" true p;
+    let s = Yojson.Safe.Util.(j |> member "score" |> to_float) in
+    check (float 0.01) "score" 0.95 s
+  in
+
+  (* ====== FIGMA_IMAGE_SIMILARITY tests ====== *)
+
+  (* -- is_space -- *)
+  let test_is_space_true () =
+    check bool "space" true (Figma_image_similarity.is_space ' ');
+    check bool "tab" true (Figma_image_similarity.is_space '\t');
+    check bool "newline" true (Figma_image_similarity.is_space '\n');
+    check bool "cr" true (Figma_image_similarity.is_space '\r')
+  in
+  let test_is_space_false () =
+    check bool "a" false (Figma_image_similarity.is_space 'a');
+    check bool "0" false (Figma_image_similarity.is_space '0');
+    check bool "#" false (Figma_image_similarity.is_space '#')
+  in
+
+  (* -- parse_ppm_header -- *)
+  let test_ppm_header_valid () =
+    let data = "P6\n10 20\n255\n" in
+    let (magic, w, h, maxv, _off) = Figma_image_similarity.parse_ppm_header data in
+    check string "magic" "P6" magic;
+    check int "w" 10 w;
+    check int "h" 20 h;
+    check int "maxv" 255 maxv
+  in
+  let test_ppm_header_with_comment () =
+    let data = "P6\n# this is a comment\n4 3\n255\n" in
+    let (magic, w, h, maxv, _off) = Figma_image_similarity.parse_ppm_header data in
+    check string "magic" "P6" magic;
+    check int "w" 4 w;
+    check int "h" 3 h;
+    check int "maxv" 255 maxv
+  in
+  let test_ppm_header_empty () =
+    let (magic, w, h, _, _) = Figma_image_similarity.parse_ppm_header "" in
+    check string "magic" "" magic;
+    check int "w" 0 w;
+    check int "h" 0 h
+  in
+  let test_ppm_header_incomplete () =
+    (* Only 2 tokens (P6, 10) — needs 4, so match falls to default *)
+    let (magic, w, _, _, _) = Figma_image_similarity.parse_ppm_header "P6 10" in
+    check string "magic" "" magic;
+    check int "w" 0 w
+  in
+
+  (* -- mse_psnr with synthetic images -- *)
+  let mk_image w h luma_val =
+    let n = w * h in
+    let luma = Array.make n luma_val in
+    let lab = Array.make n { Ciede2000.l = 50.0; a = 0.0; b = 0.0 } in
+    ({ Figma_image_similarity.width = w; height = h; lab; luma } : Figma_image_similarity.image)
+  in
+  let test_mse_psnr_identical () =
+    let img = mk_image 10 10 0.5 in
+    let (mse, psnr, w, h) = Figma_image_similarity.mse_psnr img img in
+    check (float 0.001) "mse" 0.0 mse;
+    check bool "psnr inf" true (Float.is_infinite psnr);
+    check int "w" 10 w;
+    check int "h" 10 h
+  in
+  let test_mse_psnr_different () =
+    let a = mk_image 10 10 0.0 in
+    let b = mk_image 10 10 1.0 in
+    let (mse, psnr, _, _) = Figma_image_similarity.mse_psnr a b in
+    check (float 0.001) "mse" 1.0 mse;
+    check bool "finite psnr" true (Float.is_finite psnr)
+  in
+  let test_mse_psnr_zero_area () =
+    let a = mk_image 0 0 0.5 in
+    let b = mk_image 0 0 0.5 in
+    let (mse, psnr, w, h) = Figma_image_similarity.mse_psnr a b in
+    check (float 0.001) "mse" 0.0 mse;
+    check bool "psnr inf" true (Float.is_infinite psnr);
+    check int "w" 0 w;
+    check int "h" 0 h
+  in
+  let test_mse_psnr_different_sizes () =
+    let a = mk_image 20 10 0.5 in
+    let b = mk_image 10 20 0.5 in
+    let (_, _, w, h) = Figma_image_similarity.mse_psnr a b in
+    check int "overlap_w" 10 w;
+    check int "overlap_h" 10 h
+  in
+
+  (* -- ssim_window -- *)
+  let test_ssim_window_identical () =
+    let img = mk_image 8 8 0.5 in
+    let s = Figma_image_similarity.ssim_window ~a:img ~b:img ~x0:0 ~y0:0 ~w:8 ~h:8 in
+    check (float 0.001) "perfect" 1.0 s
+  in
+  let test_ssim_window_zero () =
+    let s = Figma_image_similarity.ssim_window
+      ~a:(mk_image 8 8 0.5) ~b:(mk_image 8 8 0.5) ~x0:0 ~y0:0 ~w:0 ~h:0 in
+    check (float 0.001) "zero window" 0.0 s
+  in
+  let test_ssim_window_different () =
+    let a = mk_image 8 8 0.0 in
+    let b = mk_image 8 8 1.0 in
+    let s = Figma_image_similarity.ssim_window ~a ~b ~x0:0 ~y0:0 ~w:8 ~h:8 in
+    check bool "less than 1" true (s < 1.0)
+  in
+
+  (* -- ssim (full image) -- *)
+  let test_ssim_identical () =
+    let img = mk_image 16 16 0.5 in
+    let s = Figma_image_similarity.ssim img img ~window:8 in
+    check (float 0.001) "perfect" 1.0 s
+  in
+  let test_ssim_zero_size () =
+    let a = mk_image 0 0 0.5 in
+    let b = mk_image 0 0 0.5 in
+    let s = Figma_image_similarity.ssim a b ~window:8 in
+    check (float 0.001) "zero" 0.0 s
+  in
+  let test_ssim_negative_window () =
+    let img = mk_image 16 16 0.5 in
+    let s = Figma_image_similarity.ssim img img ~window:(-1) in
+    check (float 0.001) "uses default" 1.0 s
+  in
+  let test_ssim_too_small_for_window () =
+    let img = mk_image 4 4 0.5 in
+    let s = Figma_image_similarity.ssim img img ~window:8 in
+    check (float 0.001) "too small" 0.0 s
+  in
+
+  (* -- calculate_avg_delta_e -- *)
+  let test_delta_e_identical () =
+    let img = mk_image 10 10 0.5 in
+    let d = Figma_image_similarity.calculate_avg_delta_e img img in
+    check (float 0.001) "zero" 0.0 d
+  in
+  let test_delta_e_zero_area () =
+    let a = mk_image 0 0 0.5 in
+    let d = Figma_image_similarity.calculate_avg_delta_e a a in
+    check (float 0.001) "zero area" 0.0 d
+  in
+  let test_delta_e_different () =
+    let n = 4 * 4 in
+    let lab_a = Array.make n { Ciede2000.l = 50.0; a = 0.0; b = 0.0 } in
+    let lab_b = Array.make n { Ciede2000.l = 80.0; a = 10.0; b = (-10.0) } in
+    let a : Figma_image_similarity.image = { width = 4; height = 4; lab = lab_a; luma = Array.make n 0.5 } in
+    let b : Figma_image_similarity.image = { width = 4; height = 4; lab = lab_b; luma = Array.make n 0.7 } in
+    let d = Figma_image_similarity.calculate_avg_delta_e a b in
+    check bool "positive" true (d > 0.0)
+  in
+
+  (* ====== VISUAL_VERIFIER tests (uncovered functions) ====== *)
+
+  (* -- step_to_json -- *)
+  let test_vv_step_to_json () =
+    let step : Visual_verifier.evolution_step = {
+      step_num = 1;
+      step_ssim = 0.85;
+      step_delta_e = 5.0;
+      step_human_ssim = 0.80;
+      step_html_path = "/tmp/test.html";
+      step_png_path = "/tmp/test.png";
+      corrections_this_step = [Visual_verifier.AdjustGap 2.0];
+    } in
+    let j = Visual_verifier.step_to_json step in
+    let s = Yojson.Safe.Util.(j |> member "step" |> to_int) in
+    check int "step" 1 s;
+    let ssim = Yojson.Safe.Util.(j |> member "ssim" |> to_float) in
+    check (float 0.001) "ssim" 0.85 ssim;
+    let corr = Yojson.Safe.Util.(j |> member "corrections" |> to_list) in
+    check int "corrections count" 1 (List.length corr)
+  in
+
+  (* -- apply_color_adjustment -- *)
+  let test_vv_apply_color_no_selector () =
+    let rgba = { Figma_types.r = 1.0; g = 0.0; b = 0.0; a = 1.0 } in
+    let html = "div { color: #000000; }" in
+    let result = Visual_verifier.apply_color_adjustment "" rgba html in
+    check bool "contains red" true (
+      try ignore (Str.search_forward (Str.regexp_string "#ff0000") result 0); true
+      with Not_found -> false)
+  in
+  let test_vv_apply_color_with_selector () =
+    let rgba = { Figma_types.r = 0.0; g = 1.0; b = 0.0; a = 1.0 } in
+    let html = ".btn { background-color: #000000; padding: 10px; }" in
+    let result = Visual_verifier.apply_color_adjustment ".btn" rgba html in
+    check bool "contains green" true (
+      try ignore (Str.search_forward (Str.regexp_string "#00ff00") result 0); true
+      with Not_found -> false)
+  in
+  let test_vv_apply_color_selector_not_found () =
+    let rgba = { Figma_types.r = 1.0; g = 0.0; b = 0.0; a = 1.0 } in
+    let html = ".other { color: #000000; }" in
+    let result = Visual_verifier.apply_color_adjustment ".missing" rgba html in
+    check string "unchanged" html result
+  in
+
+  (* -- apply_single_hint -- *)
+  let test_vv_apply_single_hint_color () =
+    let rgba = { Figma_types.r = 1.0; g = 0.0; b = 0.0; a = 1.0 } in
+    let html = "div { color: #000000; }" in
+    let result = Visual_verifier.apply_single_hint (AdjustColor (".sel", rgba)) html in
+    check bool "processed" true (String.length result > 0)
+  in
+
+  (* -- apply_corrections (chain) -- *)
+  let test_vv_apply_corrections_empty () =
+    let html = "<div>hello</div>" in
+    let result = Visual_verifier.apply_corrections [] html in
+    check string "unchanged" html result
+  in
+  let test_vv_apply_corrections_chain () =
+    let html = "div { padding: 10px; gap: 5px; }" in
+    let hints = [Visual_verifier.AdjustPadding (2., 0., 0., 0.); Visual_verifier.AdjustGap 1.0] in
+    let result = Visual_verifier.apply_corrections hints html in
+    check bool "modified" true (result <> html)
+  in
+
+  (* -- mkdir_p -- *)
+  let test_vv_mkdir_p () =
+    let dir = Filename.concat (Filename.get_temp_dir_name ()) "figma_test_mkdir_p/a/b/c" in
+    Visual_verifier.mkdir_p dir;
+    check bool "exists" true (Sys.file_exists dir);
+    (* cleanup *)
+    let _ = Sys.command (Printf.sprintf "rm -rf %s" (Filename.concat (Filename.get_temp_dir_name ()) "figma_test_mkdir_p")) in
+    ()
+  in
+  let test_vv_mkdir_p_existing () =
+    let dir = Filename.get_temp_dir_name () in
+    Visual_verifier.mkdir_p dir;
+    check bool "still exists" true (Sys.file_exists dir)
+  in
+
+  (* -- copy_file -- *)
+  let test_vv_copy_file () =
+    let src = Filename.temp_file "figma_copy_src" ".txt" in
+    let dst = Filename.temp_file "figma_copy_dst" ".txt" in
+    let data = "Hello, World. This is test data for copy_file." in
+    Out_channel.with_open_bin src (fun oc -> output_string oc data);
+    Visual_verifier.copy_file ~src ~dst;
+    let result = In_channel.with_open_bin dst (fun ic ->
+      really_input_string ic (in_channel_length ic)
+    ) in
+    check string "content" data result;
+    Sys.remove src;
+    Sys.remove dst
+  in
+
+  (* -- generate_temp_filename -- *)
+  let test_vv_generate_temp_filename () =
+    let f = Visual_verifier.generate_temp_filename ~prefix:"test" ~ext:"png" in
+    check bool "has prefix" true (String.length f > 4);
+    check bool "has ext" true (Filename.check_suffix f ".png")
+  in
+
+  (* -- log_verification, log_improvement, log_hint_application -- *)
+  let test_vv_log_verification () =
+    (* This writes to .figma-ssim.log, should not crash *)
+    Visual_verifier.log_verification ~node_id:"test-node-1" ~ssim:0.95 ();
+    check bool "no crash" true true
+  in
+  let test_vv_log_verification_with_notes () =
+    Visual_verifier.log_verification ~node_id:"test-node-2" ~ssim:0.90 ~notes:"test notes" ();
+    check bool "no crash" true true
+  in
+  let test_vv_log_improvement () =
+    let improvement = Visual_verifier.log_improvement
+      ~node_id:"test-node-3" ~before_ssim:0.80 ~after_ssim:0.90
+      ~change_description:"adjusted padding" in
+    check (float 0.1) "improvement" 10.0 improvement
+  in
+  let test_vv_log_hint_application () =
+    Visual_verifier.log_hint_application
+      ~node_id:"test-node-4" ~before_ssim:0.85 ~after_ssim:0.90
+      ~hints:[Visual_verifier.AdjustPadding (1., 1., 1., 1.); Visual_verifier.AdjustGap 2.0];
+    check bool "no crash" true true
+  in
+  let test_vv_log_hint_application_negative () =
+    Visual_verifier.log_hint_application
+      ~node_id:"test-node-5" ~before_ssim:0.90 ~after_ssim:0.85
+      ~hints:[Visual_verifier.AdjustColor (".x", mk_rgba 1. 0. 0. 1.)];
+    check bool "no crash" true true
+  in
+  let test_vv_log_hint_all_types () =
+    Visual_verifier.log_hint_application
+      ~node_id:"test-node-6" ~before_ssim:0.80 ~after_ssim:0.90
+      ~hints:[
+        Visual_verifier.AdjustPadding (1., 2., 3., 4.);
+        Visual_verifier.AdjustGap 5.;
+        Visual_verifier.AdjustColor (".c", mk_rgba 0. 0. 0. 1.);
+        Visual_verifier.AdjustSize (1., 2.);
+        Visual_verifier.AdjustFontSize 3.;
+        Visual_verifier.AdjustBorderRadius 4.;
+      ];
+    check bool "no crash" true true
+  in
+
+  (* -- get_recent_logs, get_ssim_trend -- *)
+  let test_vv_get_recent_logs () =
+    (* After writing logs above, should be able to read them *)
+    let logs = Visual_verifier.get_recent_logs ~count:5 () in
+    check bool "has logs" true (List.length logs > 0)
+  in
+  let test_vv_get_ssim_trend () =
+    let trend = Visual_verifier.get_ssim_trend ~node_id:"test-node-1" in
+    check bool "has trend" true (List.length trend > 0)
+  in
+  let test_vv_get_ssim_trend_unknown () =
+    let trend = Visual_verifier.get_ssim_trend ~node_id:"nonexistent-node-xyz" in
+    check int "empty trend" 0 (List.length trend)
+  in
+
+  (* ====== RUN ALL ====== *)
+  run "verifiers-w4" [
+    ("semantic_verifier/normalize_text", [
+      test_case "simple" `Quick test_sv_normalize_text_simple;
+      test_case "newlines" `Quick test_sv_normalize_text_newlines;
+      test_case "empty" `Quick test_sv_normalize_text_empty;
+    ]);
+    ("semantic_verifier/rgba_dist_rgb", [
+      test_case "same" `Quick test_sv_rgba_dist_same;
+      test_case "different" `Quick test_sv_rgba_dist_different;
+      test_case "black_white" `Quick test_sv_rgba_dist_black_white;
+    ]);
+    ("semantic_verifier/bbox_area", [
+      test_case "normal" `Quick test_sv_bbox_area_normal;
+      test_case "zero" `Quick test_sv_bbox_area_zero;
+      test_case "single_dim" `Quick test_sv_bbox_area_single_dim_zero;
+    ]);
+    ("semantic_verifier/bbox_center", [
+      test_case "offset" `Quick test_sv_bbox_center;
+      test_case "origin" `Quick test_sv_bbox_center_origin;
+    ]);
+    ("semantic_verifier/bbox_delta", [
+      test_case "identical" `Quick test_sv_bbox_delta_identical;
+      test_case "shifted" `Quick test_sv_bbox_delta_shifted;
+    ]);
+    ("semantic_verifier/bbox_within", [
+      test_case "exact" `Quick test_sv_bbox_within_exact;
+      test_case "inside" `Quick test_sv_bbox_within_inside_tol;
+      test_case "outside" `Quick test_sv_bbox_within_outside_tol;
+    ]);
+    ("semantic_verifier/normalize_bbox", [
+      test_case "basic" `Quick test_sv_normalize_bbox;
+    ]);
+    ("semantic_verifier/pick_root_bbox", [
+      test_case "with_root" `Quick test_sv_pick_root_with_root;
+      test_case "no_root" `Quick test_sv_pick_root_no_root;
+    ]);
+    ("semantic_verifier/solid_color_of_paints", [
+      test_case "found" `Quick test_sv_solid_color_found;
+      test_case "empty" `Quick test_sv_solid_color_empty;
+      test_case "invisible" `Quick test_sv_solid_color_invisible;
+      test_case "gradient_then_solid" `Quick test_sv_solid_color_gradient_then_solid;
+    ]);
+    ("semantic_verifier/extract_expected_texts", [
+      test_case "basic" `Quick test_sv_extract_texts_basic;
+      test_case "empty_chars" `Quick test_sv_extract_texts_empty_chars;
+      test_case "no_bbox" `Quick test_sv_extract_texts_no_bbox;
+    ]);
+    ("semantic_verifier/choose_best_text_candidate", [
+      test_case "exact" `Quick test_sv_choose_exact_match;
+      test_case "no_match" `Quick test_sv_choose_no_match;
+      test_case "substring" `Quick test_sv_choose_substring_match;
+      test_case "short_no_substring" `Quick test_sv_choose_short_text_no_substring;
+      test_case "best_by_distance" `Quick test_sv_choose_best_by_distance;
+    ]);
+    ("semantic_verifier/verify", [
+      test_case "no_bbox" `Quick test_sv_verify_no_bbox;
+      test_case "root_size_mismatch" `Quick test_sv_verify_root_size_mismatch;
+      test_case "bg_mismatch" `Quick test_sv_verify_bg_mismatch;
+      test_case "border_radius" `Quick test_sv_verify_border_radius_mismatch;
+      test_case "font_size" `Quick test_sv_verify_font_size_mismatch;
+      test_case "font_weight" `Quick test_sv_verify_font_weight_mismatch;
+      test_case "text_color" `Quick test_sv_verify_text_color_mismatch;
+      test_case "score_calculation" `Quick test_sv_verify_score_calculation;
+    ]);
+    ("semantic_verifier/mismatch_to_json", [
+      test_case "root_size" `Quick test_sv_mismatch_json_root_size;
+      test_case "root_bg" `Quick test_sv_mismatch_json_root_bg;
+      test_case "root_radius" `Quick test_sv_mismatch_json_root_radius;
+      test_case "missing_text" `Quick test_sv_mismatch_json_missing_text;
+      test_case "text_bbox" `Quick test_sv_mismatch_json_text_bbox;
+      test_case "font_size" `Quick test_sv_mismatch_json_font_size;
+      test_case "font_weight" `Quick test_sv_mismatch_json_font_weight;
+      test_case "text_color" `Quick test_sv_mismatch_json_text_color;
+    ]);
+    ("semantic_verifier/json_helpers", [
+      test_case "bbox_to_json" `Quick test_sv_bbox_to_json;
+      test_case "rgba_to_json" `Quick test_sv_rgba_to_json;
+      test_case "result_to_json" `Quick test_sv_result_to_json;
+    ]);
+    ("figma_image_similarity/is_space", [
+      test_case "true" `Quick test_is_space_true;
+      test_case "false" `Quick test_is_space_false;
+    ]);
+    ("figma_image_similarity/parse_ppm_header", [
+      test_case "valid" `Quick test_ppm_header_valid;
+      test_case "comment" `Quick test_ppm_header_with_comment;
+      test_case "empty" `Quick test_ppm_header_empty;
+      test_case "incomplete" `Quick test_ppm_header_incomplete;
+    ]);
+    ("figma_image_similarity/mse_psnr", [
+      test_case "identical" `Quick test_mse_psnr_identical;
+      test_case "different" `Quick test_mse_psnr_different;
+      test_case "zero_area" `Quick test_mse_psnr_zero_area;
+      test_case "different_sizes" `Quick test_mse_psnr_different_sizes;
+    ]);
+    ("figma_image_similarity/ssim_window", [
+      test_case "identical" `Quick test_ssim_window_identical;
+      test_case "zero" `Quick test_ssim_window_zero;
+      test_case "different" `Quick test_ssim_window_different;
+    ]);
+    ("figma_image_similarity/ssim", [
+      test_case "identical" `Quick test_ssim_identical;
+      test_case "zero_size" `Quick test_ssim_zero_size;
+      test_case "negative_window" `Quick test_ssim_negative_window;
+      test_case "too_small" `Quick test_ssim_too_small_for_window;
+    ]);
+    ("figma_image_similarity/calculate_avg_delta_e", [
+      test_case "identical" `Quick test_delta_e_identical;
+      test_case "zero_area" `Quick test_delta_e_zero_area;
+      test_case "different" `Quick test_delta_e_different;
+    ]);
+    ("visual_verifier/step_to_json", [
+      test_case "basic" `Quick test_vv_step_to_json;
+    ]);
+    ("visual_verifier/apply_color_adjustment", [
+      test_case "no_selector" `Quick test_vv_apply_color_no_selector;
+      test_case "with_selector" `Quick test_vv_apply_color_with_selector;
+      test_case "selector_not_found" `Quick test_vv_apply_color_selector_not_found;
+    ]);
+    ("visual_verifier/apply_single_hint", [
+      test_case "color" `Quick test_vv_apply_single_hint_color;
+    ]);
+    ("visual_verifier/apply_corrections", [
+      test_case "empty" `Quick test_vv_apply_corrections_empty;
+      test_case "chain" `Quick test_vv_apply_corrections_chain;
+    ]);
+    ("visual_verifier/mkdir_p", [
+      test_case "create" `Quick test_vv_mkdir_p;
+      test_case "existing" `Quick test_vv_mkdir_p_existing;
+    ]);
+    ("visual_verifier/copy_file", [
+      test_case "basic" `Quick test_vv_copy_file;
+    ]);
+    ("visual_verifier/generate_temp_filename", [
+      test_case "basic" `Quick test_vv_generate_temp_filename;
+    ]);
+    ("visual_verifier/logging", [
+      test_case "log_verification" `Quick test_vv_log_verification;
+      test_case "log_with_notes" `Quick test_vv_log_verification_with_notes;
+      test_case "log_improvement" `Quick test_vv_log_improvement;
+      test_case "log_hint_application" `Quick test_vv_log_hint_application;
+      test_case "log_hint_negative" `Quick test_vv_log_hint_application_negative;
+      test_case "log_hint_all_types" `Quick test_vv_log_hint_all_types;
+    ]);
+    ("visual_verifier/get_logs", [
+      test_case "recent" `Quick test_vv_get_recent_logs;
+      test_case "trend" `Quick test_vv_get_ssim_trend;
+      test_case "trend_unknown" `Quick test_vv_get_ssim_trend_unknown;
+    ]);
+  ]

--- a/test/test_visual_handlers_w4.ml
+++ b/test/test_visual_handlers_w4.ml
@@ -1,0 +1,348 @@
+(** Coverage Wave 4: mcp_visual_handlers.ml uncovered paths.
+    Targets: handle_compare_elements (color/box/full/invalid),
+             handle_evolution_report (None run_dir, missing dir),
+             handle_compare (mode dispatch),
+             handle_image_similarity (missing args),
+             handle_verify_visual/semantic (missing args). *)
+
+open Mcp_visual_handlers
+
+(* ============== Helpers ============== *)
+
+let args_of pairs =
+  `Assoc (List.map (fun (k, v) -> (k, `String v)) pairs)
+
+let args_with kv = `Assoc kv
+
+let check_error msg result =
+  match result with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail (Printf.sprintf "expected error: %s" msg)
+
+let str_contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl > hl then false
+  else
+    let rec loop i =
+      if i > hl - nl then false
+      else if String.sub haystack i nl = needle then true
+      else loop (i + 1)
+    in loop 0
+
+let check_error_contains ~needle msg result =
+  match result with
+  | Error e ->
+      if not (str_contains ~needle e) then
+        Alcotest.fail (Printf.sprintf "%s: expected '%s' in error '%s'" msg needle e)
+  | Ok _ -> Alcotest.fail (Printf.sprintf "expected error: %s" msg)
+
+let check_ok msg result =
+  match result with
+  | Ok _ -> ()
+  | Error e -> Alcotest.fail (Printf.sprintf "expected ok for %s: %s" msg e)
+
+let check_ok_contains ~needle msg result =
+  match result with
+  | Ok json ->
+      let s = Yojson.Safe.to_string json in
+      if not (str_contains ~needle s) then
+        Alcotest.fail (Printf.sprintf "%s: expected '%s' in ok '%s'" msg needle s)
+  | Error e -> Alcotest.fail (Printf.sprintf "expected ok for %s: %s" msg e)
+
+(* ============== 1. handle_compare_elements — color ============== *)
+
+let test_compare_elements_color_hex () =
+  let args = args_of [
+    ("type", "color"); ("color1", "#FF0000"); ("color2", "#00FF00");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "color hex comparison" result;
+  check_ok_contains ~needle:"oklab_distance" "has oklab" result
+
+let test_compare_elements_color_rgb () =
+  let args = args_of [
+    ("type", "color"); ("color1", "rgb(255,0,0)"); ("color2", "rgb(0,255,0)");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "color rgb comparison" result;
+  check_ok_contains ~needle:"ciede2000" "has ciede2000" result
+
+let test_compare_elements_color_invalid () =
+  let args = args_of [
+    ("type", "color"); ("color1", "notacolor"); ("color2", "#FF0000");
+  ] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Invalid color format" "invalid color" result
+
+let test_compare_elements_color_missing () =
+  let args = args_of [("type", "color"); ("color1", "#FF0000")] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Missing color1 or color2" "missing color" result
+
+let test_compare_elements_color_both_missing () =
+  let args = args_of [("type", "color")] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Missing color1 or color2" "both missing" result
+
+(* ============== 2. handle_compare_elements — box ============== *)
+
+let test_compare_elements_box_ok () =
+  let args = args_of [
+    ("type", "box"); ("box1", "0,0,100,100"); ("box2", "10,10,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "box comparison" result;
+  check_ok_contains ~needle:"iou_value" "has iou" result
+
+let test_compare_elements_box_invalid () =
+  let args = args_of [
+    ("type", "box"); ("box1", "not,a,box,format"); ("box2", "0,0,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Invalid box format" "invalid box" result
+
+let test_compare_elements_box_missing () =
+  let args = args_of [("type", "box"); ("box1", "0,0,100,100")] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Missing box1 or box2" "missing box2" result
+
+let test_compare_elements_box_wrong_parts () =
+  let args = args_of [
+    ("type", "box"); ("box1", "0,0,100"); ("box2", "0,0,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Invalid box format" "3 parts" result
+
+(* ============== 3. handle_compare_elements — full ============== *)
+
+let test_compare_elements_full_both () =
+  let args = args_of [
+    ("type", "full");
+    ("color1", "#FF0000"); ("color2", "#0000FF");
+    ("box1", "0,0,100,100"); ("box2", "50,50,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "full with both" result;
+  check_ok_contains ~needle:"full" "type full" result
+
+let test_compare_elements_full_color_only () =
+  let args = args_of [
+    ("type", "full");
+    ("color1", "#FF0000"); ("color2", "#00FF00");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "full color only" result
+
+let test_compare_elements_full_box_only () =
+  let args = args_of [
+    ("type", "full");
+    ("box1", "0,0,200,200"); ("box2", "0,0,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "full box only" result
+
+let test_compare_elements_full_neither () =
+  let args = args_of [("type", "full")] in
+  let result = handle_compare_elements args in
+  check_ok "full neither" result
+
+let test_compare_elements_full_invalid_color () =
+  let args = args_of [
+    ("type", "full");
+    ("color1", "xyz"); ("color2", "abc");
+    ("box1", "0,0,100,100"); ("box2", "0,0,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "full invalid color falls to null" result
+
+let test_compare_elements_full_invalid_box () =
+  let args = args_of [
+    ("type", "full");
+    ("color1", "#FF0000"); ("color2", "#00FF00");
+    ("box1", "invalid"); ("box2", "0,0,100,100");
+  ] in
+  let result = handle_compare_elements args in
+  check_ok "full invalid box falls to null" result
+
+(* ============== 4. handle_compare_elements — invalid type ============== *)
+
+let test_compare_elements_invalid_type () =
+  let args = args_of [("type", "unknown")] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Invalid type" "unknown type" result
+
+let test_compare_elements_no_type () =
+  let args = `Assoc [] in
+  let result = handle_compare_elements args in
+  check_error_contains ~needle:"Invalid type" "missing type" result
+
+(* ============== 5. handle_evolution_report ============== *)
+
+let test_evolution_report_no_run_dir () =
+  (* When run_dir is None, should list recent runs *)
+  let args = `Assoc [] in
+  let result = handle_evolution_report args in
+  check_ok "no run_dir lists runs" result;
+  check_ok_contains ~needle:"recent_runs" "has recent_runs" result
+
+let test_evolution_report_missing_dir () =
+  let args = args_of [("run_dir", "/tmp/nonexistent-dir-coverage-test-12345")] in
+  let result = handle_evolution_report args in
+  check_error_contains ~needle:"not found" "missing dir" result
+
+let test_evolution_report_real_dir () =
+  (* Create a temp dir to test the existing dir path *)
+  let dir = Filename.concat (Filename.get_temp_dir_name ()) "figma-evolution-test-w4" in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let args = args_with [
+    ("run_dir", `String dir);
+    ("generate_image", `Bool false);
+  ] in
+  let result = handle_evolution_report args in
+  check_ok "existing dir" result;
+  check_ok_contains ~needle:"run_dir" "has run_dir" result;
+  check_ok_contains ~needle:"step_count" "has step_count" result;
+  (* Cleanup *)
+  (try Unix.rmdir dir with _ -> ())
+
+let test_evolution_report_with_html_dir () =
+  (* Create dir structure with html subdir and a .html file *)
+  let base = Filename.concat (Filename.get_temp_dir_name ()) "figma-evolution-test-w4-html" in
+  (try Unix.mkdir base 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let html_dir = Filename.concat base "html" in
+  (try Unix.mkdir html_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let html_file = Filename.concat html_dir "step_001.html" in
+  let oc = open_out html_file in
+  output_string oc "<html></html>";
+  close_out oc;
+  let args = args_with [
+    ("run_dir", `String base);
+    ("generate_image", `Bool false);
+  ] in
+  let result = handle_evolution_report args in
+  check_ok "dir with html" result;
+  check_ok_contains ~needle:"step_001.html" "has step file" result;
+  (* Cleanup *)
+  (try Sys.remove html_file with _ -> ());
+  (try Unix.rmdir html_dir with _ -> ());
+  (try Unix.rmdir base with _ -> ())
+
+(* ============== 6. handle_compare — mode dispatch ============== *)
+
+let test_compare_mode_elements () =
+  let args = args_of [
+    ("mode", "elements"); ("type", "color");
+    ("color1", "#FF0000"); ("color2", "#00FF00");
+  ] in
+  let result = handle_compare args in
+  check_ok "compare mode=elements" result
+
+let test_compare_mode_evolution () =
+  let args = args_with [
+    ("mode", `String "evolution");
+  ] in
+  let result = handle_compare args in
+  check_ok "compare mode=evolution" result
+
+let test_compare_mode_general_missing () =
+  let args = args_of [("mode", "general")] in
+  let result = handle_compare args in
+  check_error "compare mode=general no params" result
+
+let test_compare_mode_batch_missing () =
+  let args = args_of [("mode", "batch")] in
+  let result = handle_compare args in
+  check_error "compare mode=batch no params" result
+
+let test_compare_mode_default_missing () =
+  (* No mode specified => defaults to general *)
+  let args = `Assoc [] in
+  let result = handle_compare args in
+  check_error "compare default mode no params" result
+
+(* ============== 7. handle_image_similarity — missing args ============== *)
+
+let test_image_similarity_missing_all () =
+  let result = handle_image_similarity (`Assoc []) in
+  check_error "image_similarity missing all" result
+
+let test_image_similarity_missing_node_b () =
+  let result = handle_image_similarity (args_of [
+    ("file_key", "abc"); ("node_a_id", "1:2");
+  ]) in
+  check_error "image_similarity missing node_b" result
+
+(* ============== 8. handle_verify_visual — missing args ============== *)
+
+let test_verify_visual_missing_all () =
+  let result = handle_verify_visual (`Assoc []) in
+  check_error "verify_visual missing all" result
+
+(* ============== 9. handle_verify_semantic — missing args ============== *)
+
+let test_verify_semantic_missing_all () =
+  let result = handle_verify_semantic (`Assoc []) in
+  check_error "verify_semantic missing all" result
+
+(* ============== 10. handle_compare_regions — missing args ============== *)
+
+let test_compare_regions_missing_all () =
+  let result = handle_compare_regions (`Assoc []) in
+  check_error "compare_regions missing all" result
+
+(* ============== Test Suite ============== *)
+
+let compare_elements_tests = [
+  ("color hex", `Quick, test_compare_elements_color_hex);
+  ("color rgb", `Quick, test_compare_elements_color_rgb);
+  ("color invalid", `Quick, test_compare_elements_color_invalid);
+  ("color missing", `Quick, test_compare_elements_color_missing);
+  ("color both missing", `Quick, test_compare_elements_color_both_missing);
+  ("box ok", `Quick, test_compare_elements_box_ok);
+  ("box invalid", `Quick, test_compare_elements_box_invalid);
+  ("box missing", `Quick, test_compare_elements_box_missing);
+  ("box wrong parts", `Quick, test_compare_elements_box_wrong_parts);
+  ("full both", `Quick, test_compare_elements_full_both);
+  ("full color only", `Quick, test_compare_elements_full_color_only);
+  ("full box only", `Quick, test_compare_elements_full_box_only);
+  ("full neither", `Quick, test_compare_elements_full_neither);
+  ("full invalid color", `Quick, test_compare_elements_full_invalid_color);
+  ("full invalid box", `Quick, test_compare_elements_full_invalid_box);
+  ("invalid type", `Quick, test_compare_elements_invalid_type);
+  ("no type", `Quick, test_compare_elements_no_type);
+]
+
+let evolution_report_tests = [
+  ("no run_dir", `Quick, test_evolution_report_no_run_dir);
+  ("missing dir", `Quick, test_evolution_report_missing_dir);
+  ("real dir", `Quick, test_evolution_report_real_dir);
+  ("with html dir", `Quick, test_evolution_report_with_html_dir);
+]
+
+let compare_tests = [
+  ("mode elements", `Quick, test_compare_mode_elements);
+  ("mode evolution", `Quick, test_compare_mode_evolution);
+  ("mode general missing", `Quick, test_compare_mode_general_missing);
+  ("mode batch missing", `Quick, test_compare_mode_batch_missing);
+  ("mode default missing", `Quick, test_compare_mode_default_missing);
+]
+
+let image_similarity_tests = [
+  ("missing all", `Quick, test_image_similarity_missing_all);
+  ("missing node_b", `Quick, test_image_similarity_missing_node_b);
+]
+
+let verify_tests = [
+  ("verify visual missing", `Quick, test_verify_visual_missing_all);
+  ("verify semantic missing", `Quick, test_verify_semantic_missing_all);
+  ("compare regions missing", `Quick, test_compare_regions_missing_all);
+]
+
+let () =
+  Alcotest.run "Visual Handlers W4" [
+    ("compare_elements", compare_elements_tests);
+    ("evolution_report", evolution_report_tests);
+    ("compare", compare_tests);
+    ("image_similarity", image_similarity_tests);
+    ("verify", verify_tests);
+  ]


### PR DESCRIPTION
## Summary

bisect_ppx 커버리지 웨이브 4: 핸들러 모듈과 중간 티어 모듈 대상 테스트 추가.

- **전체 커버리지**: 57.79% → 62.38% (+4.59pp, +697 coverage points)
- **새 테스트 파일 5개**: 4,613 lines, 276+ 테스트 케이스
- **이전 웨이브**: PR #109 (A1+A2+W1), PR #111 (W3)

### 파일별 커버리지 변화

| Module | Before | After | Delta |
|--------|--------|-------|-------|
| `mcp_api_handlers.ml` | 58.63% | **82.94%** | +24.31pp |
| `semantic_verifier.ml` | 60.39% | **94.81%** | +34.42pp |
| `mcp_helpers.ml` | 87.98% | **93.41%** | +5.43pp |
| `figma_plugin_features.ml` | 65.99% | **88.51%** | +22.52pp |
| `figma_image_similarity.ml` | 65.99% | **73.10%** | +7.11pp |
| `server_metrics.ml` | 31.94% | **65.28%** | +33.34pp |
| `figma_plugin_bridge.ml` | 25.60% | **59.20%** | +33.60pp |
| `visual_verifier.ml` | 43.41% | **60.85%** | +17.44pp |
| `mcp_visual_handlers.ml` | 60.91% | **64.53%** | +3.62pp |

### 새 테스트 파일

| File | Lines | Tests | Targets |
|------|-------|-------|---------|
| `test_api_handlers_w4.ml` | 1,450 | 81 | mcp_api_handlers (effect-mocked handlers) |
| `test_verifiers_coverage_w4.ml` | 1,024 | 90 | visual_verifier, semantic_verifier, figma_image_similarity (pure math) |
| `test_helpers_effects_w4.ml` | 1,132 | ~30 | mcp_helpers, server_metrics (Eio.Mutex wrapped) |
| `test_plugin_w4.ml` | 659 | 74 | figma_plugin_bridge, figma_plugin_features, mcp_plugin_handlers |
| `test_visual_handlers_w4.ml` | 348 | 31 | mcp_visual_handlers (compare_elements, evolution_report) |

### 기술 노트

- OCaml 5.x algebraic effects (`Figma_effects.run_with_mock`) 패턴으로 I/O 핸들러를 순수 함수처럼 테스트
- `Eio_main.run` wrapper로 `server_metrics.ml`의 module-level `Eio.Mutex` 안전하게 테스트
- `Figma_cache.invalidate()` per-test로 cross-test contamination 방지

## Test plan

- [x] `dune runtest` — 전체 테스트 통과
- [x] `bisect-ppx-report summary` — 62.38% 확인
- [x] 개별 테스트 바이너리 검증 (5개 모두 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)