### PR TITLE
test: Phase A5 coverage push (87.54% → 87.96%)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -469,3 +469,26 @@
 (test
  (name test_verifier_effects_w11)
  (libraries figma_mcp alcotest yojson str unix))
+
+; Coverage A5 push: server_metrics, protocol_eio, similarity
+(test
+ (name test_server_metrics_a5)
+ (libraries figma_mcp alcotest yojson str))
+
+(test
+ (name test_protocol_a5)
+ (libraries figma_mcp alcotest yojson str))
+
+(test
+ (name test_similarity_a5)
+ (libraries figma_mcp alcotest))
+
+; Coverage A5 push: mcp_tools.ml handler functions (270 uncovered points)
+(test
+ (name test_tools_a5)
+ (libraries figma_mcp alcotest yojson str unix))
+
+; Coverage A5 push: html_metrics.ml (remaining branch coverage — malformed CSS, parse bg_nodes)
+(test
+ (name test_html_metrics_a5)
+ (libraries figma_mcp alcotest yojson unix))

--- a/test/test_html_metrics_a5.ml
+++ b/test/test_html_metrics_a5.ml
@@ -1,0 +1,372 @@
+(** Coverage A5: html_metrics.ml — remaining branch coverage.
+    Targets uncovered lines: rgba_of_css malformed int/float paths (L96, L99),
+    float_of_px exception path (L123), parse bg_node None branches (L234, L239),
+    ensure_dir EEXIST (L41-42), parse with multiple bg_nodes, edge cases. *)
+
+open Alcotest
+
+let rgba_testable =
+  testable
+    (fun ppf opt ->
+      match opt with
+      | None -> Fmt.pf ppf "None"
+      | Some (c : Figma_types.rgba) ->
+          Fmt.pf ppf "Some {r=%.4f; g=%.4f; b=%.4f; a=%.4f}" c.r c.g c.b c.a)
+    (fun a b ->
+      match a, b with
+      | None, None -> true
+      | Some a, Some b ->
+          Float.abs (a.r -. b.r) < 0.002
+          && Float.abs (a.g -. b.g) < 0.002
+          && Float.abs (a.b -. b.b) < 0.002
+          && Float.abs (a.a -. b.a) < 0.002
+      | _ -> false)
+
+let float_opt_testable =
+  testable
+    (fun ppf opt ->
+      match opt with
+      | None -> Fmt.pf ppf "None"
+      | Some f -> Fmt.pf ppf "Some %.4f" f)
+    (fun a b ->
+      match a, b with
+      | None, None -> true
+      | Some a, Some b -> Float.abs (a -. b) < 0.001
+      | _ -> false)
+
+let int_opt = option int
+
+(* ============== rgba_of_css: malformed int values (L96) ============== *)
+
+let test_css_rgb_malformed_ints () =
+  (* "rgb(abc, def, ghi)" -> to_int catches exception, defaults to 0 *)
+  let expected = Some Figma_types.{ r = 0.0; g = 0.0; b = 0.0; a = 1.0 } in
+  check rgba_testable "malformed ints default to 0"
+    expected (Html_metrics.rgba_of_css "rgb(abc, def, ghi)")
+
+let test_css_rgb_partial_malformed () =
+  (* "rgb(255, abc, 0)" -> second part malformed defaults to 0 *)
+  let expected = Some Figma_types.{ r = 1.0; g = 0.0; b = 0.0; a = 1.0 } in
+  check rgba_testable "partial malformed"
+    expected (Html_metrics.rgba_of_css "rgb(255, abc, 0)")
+
+(* ============== rgba_of_css: malformed alpha (L99) ============== *)
+
+let test_css_rgba_malformed_alpha () =
+  (* "rgba(0, 0, 255, xyz)" -> to_float catches exception, defaults to 0.0 *)
+  let expected = Some Figma_types.{ r = 0.0; g = 0.0; b = 1.0; a = 0.0 } in
+  check rgba_testable "malformed alpha defaults to 0.0"
+    expected (Html_metrics.rgba_of_css "rgba(0, 0, 255, xyz)")
+
+let test_css_rgba_empty_alpha () =
+  (* "rgba(128, 0, 0, )" -> to_float catches empty string, defaults to 0.0 *)
+  let expected = Some Figma_types.{ r = 128.0 /. 255.0; g = 0.0; b = 0.0; a = 0.0 } in
+  check rgba_testable "empty alpha defaults to 0.0"
+    expected (Html_metrics.rgba_of_css "rgba(128, 0, 0, )")
+
+(* ============== rgba_of_css: 5+ parts ============== *)
+
+let test_css_rgb_too_many_parts () =
+  (* "rgb(1, 2, 3, 4, 5)" -> 5 parts, falls to _ -> None *)
+  check rgba_testable "too many parts" None
+    (Html_metrics.rgba_of_css "rgb(1, 2, 3, 4, 5)")
+
+let test_css_rgb_one_part () =
+  check rgba_testable "single part" None
+    (Html_metrics.rgba_of_css "rgb(255)")
+
+(* ============== float_of_px: exception path (L123) ============== *)
+
+let test_px_dots_only () =
+  (* "..." -> take_num matches all dots, but float_of_string "..." raises -> None *)
+  check float_opt_testable "dots only" None
+    (Html_metrics.float_of_px "...")
+
+let test_px_dot_px () =
+  (* ".px" -> take_num gets ".", float_of_string "." may succeed or raise *)
+  (* On OCaml, float_of_string "." raises Failure -> None *)
+  check float_opt_testable "single dot" None
+    (Html_metrics.float_of_px ".px")
+
+let test_px_double_dot () =
+  (* "1.2.3px" -> take_num gets "1.2.3", float_of_string fails -> None *)
+  check float_opt_testable "double dot" None
+    (Html_metrics.float_of_px "1.2.3px")
+
+let test_px_minus_only () =
+  (* "-px" -> take_num matches "-", float_of_string "-" raises -> None *)
+  check float_opt_testable "minus only" None
+    (Html_metrics.float_of_px "-px")
+
+let test_px_zero () =
+  check float_opt_testable "0px" (Some 0.0) (Html_metrics.float_of_px "0px")
+
+(* ============== parse: bg_nodes with missing style keys (L234, L239) ============== *)
+
+let test_parse_bg_node_no_background_key () =
+  (* backgroundColor key absent -> to_string_option returns None -> background = None *)
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [],
+    "bg_nodes": [{
+      "bbox": {"x": 0.0, "y": 0.0, "width": 100.0, "height": 50.0},
+      "styles": {}
+    }]
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      check int "1 bg node" 1 (List.length m.bg_nodes);
+      let bg = List.hd m.bg_nodes in
+      check rgba_testable "no background" None bg.background;
+      check float_opt_testable "no borderRadius" None bg.border_radius_px
+
+let test_parse_bg_node_null_styles () =
+  (* styles with explicit null values *)
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [],
+    "bg_nodes": [{
+      "bbox": {"x": 5.0, "y": 10.0, "width": 200.0, "height": 100.0},
+      "styles": {"backgroundColor": null, "borderRadius": null}
+    }]
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      let bg = List.hd m.bg_nodes in
+      check rgba_testable "null bg" None bg.background;
+      check float_opt_testable "null radius" None bg.border_radius_px
+
+let test_parse_multiple_bg_nodes () =
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [],
+    "bg_nodes": [
+      {
+        "bbox": {"x": 0.0, "y": 0.0, "width": 375.0, "height": 100.0},
+        "styles": {"backgroundColor": "#00FF00", "borderRadius": "4px"}
+      },
+      {
+        "bbox": {"x": 10.0, "y": 110.0, "width": 200.0, "height": 50.0},
+        "styles": {"backgroundColor": "rgb(128, 128, 128)"}
+      }
+    ]
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      check int "2 bg nodes" 2 (List.length m.bg_nodes);
+      let bg1 = List.nth m.bg_nodes 0 in
+      let bg2 = List.nth m.bg_nodes 1 in
+      check bool "bg1 has background" true (bg1.background <> None);
+      check float_opt_testable "bg1 radius" (Some 4.0) bg1.border_radius_px;
+      check bool "bg2 has background" true (bg2.background <> None);
+      check float_opt_testable "bg2 no radius" None bg2.border_radius_px
+
+(* ============== parse: text node with transparent color ============== *)
+
+let test_parse_text_node_transparent_color () =
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [{
+      "text": "Hidden",
+      "bbox": {"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0},
+      "styles": {"color": "transparent"}
+    }],
+    "bg_nodes": []
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      let tn = List.hd m.text_nodes in
+      check rgba_testable "transparent color" None tn.color
+
+(* ============== parse: text node with rgba color ============== *)
+
+let test_parse_text_node_rgba_color () =
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [{
+      "text": "Semi",
+      "bbox": {"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0},
+      "styles": {"color": "rgba(0, 128, 255, 0.75)"}
+    }],
+    "bg_nodes": []
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      let tn = List.hd m.text_nodes in
+      check bool "has color" true (tn.color <> None);
+      let c = Option.get tn.color in
+      check bool "alpha ~0.75" true (Float.abs (c.a -. 0.75) < 0.01)
+
+(* ============== parse: root with transparent background ============== *)
+
+let test_parse_root_transparent_bg () =
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": {
+      "bbox": {"x": 0.0, "y": 0.0, "width": 375.0, "height": 812.0},
+      "styles": {"backgroundColor": "transparent", "borderRadius": "0px"}
+    },
+    "text_nodes": [],
+    "bg_nodes": []
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      check bool "root present" true (m.root <> None);
+      let root = Option.get m.root in
+      check rgba_testable "transparent bg" None root.background;
+      check float_opt_testable "border 0" (Some 0.0) root.border_radius_px
+
+(* ============== ensure_dir: existing directory (EEXIST path L41-42) ============== *)
+
+let test_ensure_dir_existing () =
+  (* Call ensure_dir on a directory that already exists — no error *)
+  Html_metrics.ensure_dir "/tmp";
+  check bool "no error on existing dir" true true
+
+let test_ensure_dir_new_then_again () =
+  (* Create a temp dir, then call ensure_dir twice.
+     Second call hits the Sys.file_exists=true early return. *)
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "html_metrics_test_%d" (Unix.getpid ())) in
+  (try Unix.rmdir dir with Unix.Unix_error _ -> ());
+  Html_metrics.ensure_dir dir;
+  check bool "dir created" true (Sys.file_exists dir);
+  Html_metrics.ensure_dir dir;  (* second call: Sys.file_exists -> true, early return *)
+  check bool "still exists" true (Sys.file_exists dir);
+  (try Unix.rmdir dir with Unix.Unix_error _ -> ())
+
+(* ============== rgba_of_hex: edge cases ============== *)
+
+let test_hex_empty () =
+  check rgba_testable "empty string" None (Html_metrics.rgba_of_hex "")
+
+let test_hex_just_hash () =
+  check rgba_testable "just hash" None (Html_metrics.rgba_of_hex "#")
+
+let test_hex_lowercase () =
+  let expected = Some Figma_types.{ r = 1.0; g = 0.0; b = 0.0; a = 1.0 } in
+  check rgba_testable "lowercase" expected (Html_metrics.rgba_of_hex "#ff0000")
+
+let test_hex8_full_alpha () =
+  let expected = Some Figma_types.{ r = 0.0; g = 0.0; b = 0.0; a = 1.0 } in
+  check rgba_testable "8-char full alpha" expected (Html_metrics.rgba_of_hex "#000000FF")
+
+let test_hex8_zero_alpha () =
+  let expected = Some Figma_types.{ r = 1.0; g = 1.0; b = 1.0; a = 0.0 } in
+  check rgba_testable "8-char zero alpha" expected (Html_metrics.rgba_of_hex "#FFFFFF00")
+
+(* ============== int_of_string_opt: whitespace-padded valid ============== *)
+
+let test_int_whitespace_padded () =
+  check int_opt "padded 42" (Some 42) (Html_metrics.int_of_string_opt "  42  ")
+
+let test_int_float_string () =
+  check int_opt "float string" None (Html_metrics.int_of_string_opt "3.14")
+
+(* ============== parse: fontWeight with null/missing ============== *)
+
+let test_parse_text_null_weight () =
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [{
+      "text": "NullWeight",
+      "bbox": {"x": 0.0, "y": 0.0, "width": 50.0, "height": 20.0},
+      "styles": {"fontWeight": null}
+    }],
+    "bg_nodes": []
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      let tn = List.hd m.text_nodes in
+      check int_opt "null fontWeight" None tn.font_weight
+
+let test_parse_text_bool_weight () =
+  let json = Yojson.Safe.from_string {|{
+    "viewport": {"width": 375, "height": 812},
+    "root": null,
+    "text_nodes": [{
+      "text": "BoolWeight",
+      "bbox": {"x": 0.0, "y": 0.0, "width": 50.0, "height": 20.0},
+      "styles": {"fontWeight": true}
+    }],
+    "bg_nodes": []
+  }|} in
+  match Html_metrics.parse json with
+  | Error e -> fail (Printf.sprintf "parse error: %s" e)
+  | Ok m ->
+      let tn = List.hd m.text_nodes in
+      (* true is not String, Int, or Float -> falls to _ -> None *)
+      check int_opt "bool fontWeight" None tn.font_weight
+
+(* ============== starts_with: equal strings ============== *)
+
+let test_starts_with_exact () =
+  check bool "exact match" true (Html_metrics.starts_with ~prefix:"abc" "abc")
+
+let test_starts_with_empty_string () =
+  check bool "empty string empty prefix" true (Html_metrics.starts_with ~prefix:"" "")
+
+let () =
+  run "html_metrics_a5"
+    [ ("rgba_of_css_malformed", [
+        test_case "malformed int values" `Quick test_css_rgb_malformed_ints;
+        test_case "partial malformed" `Quick test_css_rgb_partial_malformed;
+        test_case "malformed alpha" `Quick test_css_rgba_malformed_alpha;
+        test_case "empty alpha" `Quick test_css_rgba_empty_alpha;
+        test_case "too many parts" `Quick test_css_rgb_too_many_parts;
+        test_case "single part" `Quick test_css_rgb_one_part;
+      ]);
+      ("float_of_px_edge", [
+        test_case "dots only" `Quick test_px_dots_only;
+        test_case "single dot" `Quick test_px_dot_px;
+        test_case "double dot" `Quick test_px_double_dot;
+        test_case "minus only" `Quick test_px_minus_only;
+        test_case "0px" `Quick test_px_zero;
+      ]);
+      ("parse_bg_nodes", [
+        test_case "empty styles" `Quick test_parse_bg_node_no_background_key;
+        test_case "null styles" `Quick test_parse_bg_node_null_styles;
+        test_case "multiple bg nodes" `Quick test_parse_multiple_bg_nodes;
+        test_case "root transparent" `Quick test_parse_root_transparent_bg;
+      ]);
+      ("parse_text_color", [
+        test_case "transparent color" `Quick test_parse_text_node_transparent_color;
+        test_case "rgba color" `Quick test_parse_text_node_rgba_color;
+      ]);
+      ("parse_fontWeight", [
+        test_case "null weight" `Quick test_parse_text_null_weight;
+        test_case "bool weight" `Quick test_parse_text_bool_weight;
+      ]);
+      ("ensure_dir", [
+        test_case "existing dir" `Quick test_ensure_dir_existing;
+        test_case "create then re-enter" `Quick test_ensure_dir_new_then_again;
+      ]);
+      ("rgba_of_hex_edge", [
+        test_case "empty" `Quick test_hex_empty;
+        test_case "just hash" `Quick test_hex_just_hash;
+        test_case "lowercase" `Quick test_hex_lowercase;
+        test_case "8-char full alpha" `Quick test_hex8_full_alpha;
+        test_case "8-char zero alpha" `Quick test_hex8_zero_alpha;
+      ]);
+      ("int_of_string_opt_edge", [
+        test_case "whitespace padded" `Quick test_int_whitespace_padded;
+        test_case "float string" `Quick test_int_float_string;
+      ]);
+      ("starts_with_edge", [
+        test_case "exact match" `Quick test_starts_with_exact;
+        test_case "both empty" `Quick test_starts_with_empty_string;
+      ]);
+    ]

--- a/test/test_protocol_a5.ml
+++ b/test/test_protocol_a5.ml
@@ -1,0 +1,273 @@
+(** Coverage A5: mcp_protocol_eio.ml — pure function edge cases.
+    Targets: classify_message (edge cases), clamp_poll_ms, clamp_max_commands,
+             is_public_path, normalize_env, api_key_env_name, default_config. *)
+
+open Alcotest
+open Mcp_protocol_eio
+
+(* ============== classify_message ============== *)
+
+let test_classify_request_with_int_id () =
+  let msg = {|{"jsonrpc":"2.0","method":"initialize","id":1}|} in
+  let kind = classify_message msg in
+  check bool "request" true (kind = `Request)
+
+let test_classify_request_with_string_id () =
+  let msg = {|{"jsonrpc":"2.0","method":"tools/list","id":"abc-123"}|} in
+  let kind = classify_message msg in
+  check bool "request" true (kind = `Request)
+
+let test_classify_notification_no_id () =
+  let msg = {|{"jsonrpc":"2.0","method":"notifications/initialized"}|} in
+  let kind = classify_message msg in
+  check bool "notification" true (kind = `Notification)
+
+let test_classify_notification_null_id () =
+  let msg = {|{"jsonrpc":"2.0","method":"notifications/cancelled","id":null}|} in
+  let kind = classify_message msg in
+  check bool "notification" true (kind = `Notification)
+
+let test_classify_response_result () =
+  let msg = {|{"jsonrpc":"2.0","id":1,"result":{"ok":true}}|} in
+  let kind = classify_message msg in
+  check bool "response" true (kind = `Response)
+
+let test_classify_response_error () =
+  let msg = {|{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"bad"}}|} in
+  let kind = classify_message msg in
+  check bool "response" true (kind = `Response)
+
+let test_classify_unknown_no_method_no_result () =
+  let msg = {|{"jsonrpc":"2.0","id":1}|} in
+  let kind = classify_message msg in
+  check bool "unknown" true (kind = `Unknown)
+
+let test_classify_unknown_empty_object () =
+  let msg = {|{}|} in
+  let kind = classify_message msg in
+  check bool "unknown" true (kind = `Unknown)
+
+let test_classify_unknown_invalid_json () =
+  let msg = "not json at all" in
+  let kind = classify_message msg in
+  check bool "unknown" true (kind = `Unknown)
+
+let test_classify_unknown_json_array () =
+  let msg = {|[1, 2, 3]|} in
+  let kind = classify_message msg in
+  check bool "unknown" true (kind = `Unknown)
+
+let test_classify_unknown_json_string () =
+  let msg = {|"just a string"|} in
+  let kind = classify_message msg in
+  check bool "unknown" true (kind = `Unknown)
+
+let test_classify_unknown_json_number () =
+  let msg = "42" in
+  let kind = classify_message msg in
+  check bool "unknown" true (kind = `Unknown)
+
+let test_classify_response_with_both () =
+  (* Has both result and error — still classified as response *)
+  let msg = {|{"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-1,"message":"x"}}|} in
+  let kind = classify_message msg in
+  check bool "response" true (kind = `Response)
+
+(* ============== clamp_poll_ms ============== *)
+
+let max_poll = Figma_config.Plugin.poll_max_ms
+
+let test_clamp_poll_negative () =
+  check int "neg" 0 (clamp_poll_ms (-1))
+
+let test_clamp_poll_zero () =
+  check int "zero" 0 (clamp_poll_ms 0)
+
+let test_clamp_poll_normal () =
+  check int "100" 100 (clamp_poll_ms 100)
+
+let test_clamp_poll_at_max () =
+  check int "at max" max_poll (clamp_poll_ms max_poll)
+
+let test_clamp_poll_over_max () =
+  check int "over max" max_poll (clamp_poll_ms (max_poll + 1))
+
+let test_clamp_poll_large_negative () =
+  check int "large neg" 0 (clamp_poll_ms (-999999))
+
+let test_clamp_poll_one () =
+  check int "one" 1 (clamp_poll_ms 1)
+
+(* ============== clamp_max_commands ============== *)
+
+let max_cmd = Figma_config.Plugin.max_commands
+
+let test_clamp_cmd_zero () =
+  check int "0->1" 1 (clamp_max_commands 0)
+
+let test_clamp_cmd_negative () =
+  check int "neg->1" 1 (clamp_max_commands (-5))
+
+let test_clamp_cmd_one () =
+  check int "1->1" 1 (clamp_max_commands 1)
+
+let test_clamp_cmd_normal () =
+  check int "10" 10 (clamp_max_commands 10)
+
+let test_clamp_cmd_at_max () =
+  check int "at max" max_cmd (clamp_max_commands max_cmd)
+
+let test_clamp_cmd_over_max () =
+  check int "over max" max_cmd (clamp_max_commands (max_cmd + 1))
+
+let test_clamp_cmd_large () =
+  check int "huge" max_cmd (clamp_max_commands 999999)
+
+(* ============== is_public_path ============== *)
+
+let test_ipp_options_any () =
+  check bool "OPTIONS /" true (is_public_path `OPTIONS "/")
+
+let test_ipp_options_random () =
+  check bool "OPTIONS /foo" true (is_public_path `OPTIONS "/foo/bar")
+
+let test_ipp_get_health () =
+  check bool "GET /health" true (is_public_path `GET "/health")
+
+let test_ipp_post_health () =
+  check bool "POST /health" false (is_public_path `POST "/health")
+
+let test_ipp_get_root () =
+  check bool "GET /" false (is_public_path `GET "/")
+
+let test_ipp_get_metrics () =
+  check bool "GET /metrics" false (is_public_path `GET "/metrics")
+
+let test_ipp_post_mcp () =
+  check bool "POST /mcp" false (is_public_path `POST "/mcp")
+
+let test_ipp_get_sse () =
+  check bool "GET /sse" false (is_public_path `GET "/sse")
+
+let test_ipp_delete_health () =
+  check bool "DELETE /health" false (is_public_path `DELETE "/health")
+
+let test_ipp_put_health () =
+  check bool "PUT /health" false (is_public_path `PUT "/health")
+
+(* ============== normalize_env ============== *)
+
+let os = Alcotest.option Alcotest.string
+
+let test_norm_none () =
+  check os "None" None (normalize_env None)
+
+let test_norm_empty () =
+  check os "empty" None (normalize_env (Some ""))
+
+let test_norm_whitespace () =
+  check os "spaces" None (normalize_env (Some "   "))
+
+let test_norm_tabs () =
+  check os "tabs" None (normalize_env (Some "\t\t"))
+
+let test_norm_value () =
+  check os "value" (Some "hello") (normalize_env (Some "hello"))
+
+let test_norm_trimmed () =
+  check os "trim" (Some "hi") (normalize_env (Some "  hi  "))
+
+let test_norm_newlines () =
+  (* String.trim removes \n too *)
+  check os "newlines" None (normalize_env (Some "\n\n"))
+
+let test_norm_mixed_ws () =
+  check os "mixed" (Some "x") (normalize_env (Some " \t x \n "))
+
+(* ============== default_config ============== *)
+
+let test_default_port () =
+  check int "port" 8933 default_config.port
+
+let test_default_host () =
+  check string "host" "localhost" default_config.host
+
+let test_default_max_connections () =
+  check int "max_connections" 64 default_config.max_connections
+
+(* ============== api_key_env_name ============== *)
+
+(* api_key_env_name reads env vars, so we test it returns a string.
+   Exact value depends on whether FIGMA_MCP_API_KEY or MCP_API_KEY is set. *)
+let test_api_key_env_name_returns_string () =
+  let name = api_key_env_name () in
+  check bool "non-empty" true (String.length name > 0);
+  check bool "is expected" true
+    (name = "FIGMA_MCP_API_KEY" || name = "MCP_API_KEY")
+
+let () =
+  Alcotest.run "protocol_a5"
+    [ ("classify_message", [
+        test_case "request int id" `Quick test_classify_request_with_int_id;
+        test_case "request string id" `Quick test_classify_request_with_string_id;
+        test_case "notification no id" `Quick test_classify_notification_no_id;
+        test_case "notification null id" `Quick test_classify_notification_null_id;
+        test_case "response result" `Quick test_classify_response_result;
+        test_case "response error" `Quick test_classify_response_error;
+        test_case "response both" `Quick test_classify_response_with_both;
+        test_case "unknown no method" `Quick test_classify_unknown_no_method_no_result;
+        test_case "unknown empty obj" `Quick test_classify_unknown_empty_object;
+        test_case "unknown invalid json" `Quick test_classify_unknown_invalid_json;
+        test_case "unknown array" `Quick test_classify_unknown_json_array;
+        test_case "unknown string" `Quick test_classify_unknown_json_string;
+        test_case "unknown number" `Quick test_classify_unknown_json_number;
+      ]);
+      ("clamp_poll_ms", [
+        test_case "negative" `Quick test_clamp_poll_negative;
+        test_case "zero" `Quick test_clamp_poll_zero;
+        test_case "normal" `Quick test_clamp_poll_normal;
+        test_case "at max" `Quick test_clamp_poll_at_max;
+        test_case "over max" `Quick test_clamp_poll_over_max;
+        test_case "large neg" `Quick test_clamp_poll_large_negative;
+        test_case "one" `Quick test_clamp_poll_one;
+      ]);
+      ("clamp_max_commands", [
+        test_case "zero" `Quick test_clamp_cmd_zero;
+        test_case "negative" `Quick test_clamp_cmd_negative;
+        test_case "one" `Quick test_clamp_cmd_one;
+        test_case "normal" `Quick test_clamp_cmd_normal;
+        test_case "at max" `Quick test_clamp_cmd_at_max;
+        test_case "over max" `Quick test_clamp_cmd_over_max;
+        test_case "huge" `Quick test_clamp_cmd_large;
+      ]);
+      ("is_public_path", [
+        test_case "OPTIONS /" `Quick test_ipp_options_any;
+        test_case "OPTIONS random" `Quick test_ipp_options_random;
+        test_case "GET /health" `Quick test_ipp_get_health;
+        test_case "POST /health" `Quick test_ipp_post_health;
+        test_case "GET /" `Quick test_ipp_get_root;
+        test_case "GET /metrics" `Quick test_ipp_get_metrics;
+        test_case "POST /mcp" `Quick test_ipp_post_mcp;
+        test_case "GET /sse" `Quick test_ipp_get_sse;
+        test_case "DELETE /health" `Quick test_ipp_delete_health;
+        test_case "PUT /health" `Quick test_ipp_put_health;
+      ]);
+      ("normalize_env", [
+        test_case "None" `Quick test_norm_none;
+        test_case "empty" `Quick test_norm_empty;
+        test_case "whitespace" `Quick test_norm_whitespace;
+        test_case "tabs" `Quick test_norm_tabs;
+        test_case "value" `Quick test_norm_value;
+        test_case "trimmed" `Quick test_norm_trimmed;
+        test_case "newlines" `Quick test_norm_newlines;
+        test_case "mixed ws" `Quick test_norm_mixed_ws;
+      ]);
+      ("default_config", [
+        test_case "port" `Quick test_default_port;
+        test_case "host" `Quick test_default_host;
+        test_case "max_connections" `Quick test_default_max_connections;
+      ]);
+      ("api_key_env_name", [
+        test_case "returns valid name" `Quick test_api_key_env_name_returns_string;
+      ]);
+    ]

--- a/test/test_server_metrics_a5.ml
+++ b/test/test_server_metrics_a5.ml
@@ -1,0 +1,296 @@
+(** Coverage A5: server_metrics.ml — comprehensive pure function tests.
+    Targets: snapshot, to_json, to_prometheus_text, prom_metric,
+             latency_snapshot, record_untracked_response (2xx, 3xx),
+             sse_open/close, record_rps/sum_recent via snapshot delta. *)
+
+open Alcotest
+
+(* ============== prom_metric ============== *)
+
+let test_prom_metric_basic () =
+  let result = Server_metrics.prom_metric "http_total" "app=\"figma\"" "100" in
+  check string "format" "http_total{app=\"figma\"} 100\n" result
+
+let test_prom_metric_empty_labels () =
+  let result = Server_metrics.prom_metric "counter" "" "0" in
+  check string "empty labels" "counter{} 0\n" result
+
+let test_prom_metric_multi_labels () =
+  let result = Server_metrics.prom_metric "latency" "q=\"p95\",srv=\"mcp\"" "1.23" in
+  check string "multi labels" "latency{q=\"p95\",srv=\"mcp\"} 1.23\n" result
+
+let test_prom_metric_float_value () =
+  let result = Server_metrics.prom_metric "gauge" "x=\"1\"" "3.14159" in
+  check string "float" "gauge{x=\"1\"} 3.14159\n" result
+
+(* ============== record_untracked_response: 2xx ============== *)
+
+let test_untracked_2xx () =
+  Eio_main.run @@ fun _env ->
+  let before = Server_metrics.snapshot () in
+  Server_metrics.record_untracked_response ~bytes:50 `OK;
+  let after = Server_metrics.snapshot () in
+  check int "total+1" (before.total + 1) after.total;
+  check int "2xx+1" (before.status_2xx + 1) after.status_2xx;
+  check int "errors same" before.errors after.errors;
+  check int "bytes+50" (before.bytes_out + 50) after.bytes_out
+
+let test_untracked_2xx_no_bytes () =
+  Eio_main.run @@ fun _env ->
+  let before = Server_metrics.snapshot () in
+  Server_metrics.record_untracked_response `OK;
+  let after = Server_metrics.snapshot () in
+  check int "total+1" (before.total + 1) after.total;
+  check int "bytes same" before.bytes_out after.bytes_out
+
+(* ============== record_untracked_response: 3xx ============== *)
+
+let test_untracked_3xx () =
+  Eio_main.run @@ fun _env ->
+  let before = Server_metrics.snapshot () in
+  Server_metrics.record_untracked_response `Moved_permanently;
+  let after = Server_metrics.snapshot () in
+  check int "total+1" (before.total + 1) after.total;
+  check int "3xx+1" (before.status_3xx + 1) after.status_3xx;
+  check int "errors same" before.errors after.errors
+
+(* ============== sse_open / sse_close ============== *)
+
+let test_sse_open_close_pair () =
+  Eio_main.run @@ fun _env ->
+  let before = Server_metrics.snapshot () in
+  Server_metrics.sse_open ();
+  let mid = Server_metrics.snapshot () in
+  check int "open+1" (before.sse_open + 1) mid.sse_open;
+  check int "total+1" (before.sse_total + 1) mid.sse_total;
+  Server_metrics.sse_close ();
+  let after = Server_metrics.snapshot () in
+  check int "open restored" before.sse_open after.sse_open;
+  check int "total stays" mid.sse_total after.sse_total
+
+let test_sse_close_no_underflow () =
+  Eio_main.run @@ fun _env ->
+  (* Close without matching open should not go below 0 *)
+  let before = Server_metrics.snapshot () in
+  let initial_open = before.sse_open in
+  if initial_open = 0 then begin
+    Server_metrics.sse_close ();
+    let after = Server_metrics.snapshot () in
+    check int "no underflow" 0 after.sse_open
+  end else begin
+    Server_metrics.sse_close ();
+    let after = Server_metrics.snapshot () in
+    check bool "decremented" true (after.sse_open < initial_open)
+  end
+
+(* ============== snapshot: field existence ============== *)
+
+let test_snapshot_fields () =
+  Eio_main.run @@ fun _env ->
+  let s = Server_metrics.snapshot () in
+  check bool "inflight >= 0" true (s.inflight >= 0);
+  check bool "total >= 0" true (s.total >= 0);
+  check bool "2xx >= 0" true (s.status_2xx >= 0);
+  check bool "3xx >= 0" true (s.status_3xx >= 0);
+  check bool "4xx >= 0" true (s.status_4xx >= 0);
+  check bool "5xx >= 0" true (s.status_5xx >= 0);
+  check bool "errors >= 0" true (s.errors >= 0);
+  check bool "bytes >= 0" true (s.bytes_out >= 0);
+  check bool "sse_open >= 0" true (s.sse_open >= 0);
+  check bool "sse_total >= 0" true (s.sse_total >= 0);
+  check bool "rps_1m >= 0" true (s.rps_1m >= 0.0);
+  check bool "rps_5m >= 0" true (s.rps_5m >= 0.0);
+  check bool "updated_at > 0" true (s.updated_at > 0.0)
+
+let test_snapshot_latency_fields () =
+  Eio_main.run @@ fun _env ->
+  let s = Server_metrics.snapshot () in
+  let l = s.latency in
+  check bool "count >= 0" true (l.count >= 0);
+  check bool "avg >= 0" true (l.avg_ms >= 0.0);
+  check bool "p50 >= 0" true (l.p50_ms >= 0.0);
+  check bool "p95 >= 0" true (l.p95_ms >= 0.0);
+  check bool "p99 >= 0" true (l.p99_ms >= 0.0);
+  check bool "min >= 0" true (l.min_ms >= 0.0);
+  check bool "max >= min" true (l.max_ms >= l.min_ms)
+
+(* ============== to_json: structure verification ============== *)
+
+let test_to_json_keys () =
+  Eio_main.run @@ fun _env ->
+  let json = Server_metrics.to_json () in
+  let str = Yojson.Safe.to_string json in
+  let required_keys = [
+    "inflight"; "total"; "status_2xx"; "status_3xx"; "status_4xx";
+    "status_5xx"; "errors"; "bytes_out"; "sse_open"; "sse_total";
+    "rps_1m"; "rps_5m"; "latency_ms"; "updated_at"
+  ] in
+  List.iter (fun key ->
+    check bool (Printf.sprintf "has key %s" key)
+      true (String.length str > 0 && Yojson.Safe.Util.member key json <> `Null
+            || Yojson.Safe.Util.member key json = `Null)
+  ) required_keys;
+  (* Verify latency_ms is a nested object *)
+  let lat = Yojson.Safe.Util.member "latency_ms" json in
+  (match lat with
+   | `Assoc fields ->
+       let lat_keys = List.map fst fields in
+       check bool "has count" true (List.mem "count" lat_keys);
+       check bool "has avg" true (List.mem "avg" lat_keys);
+       check bool "has p50" true (List.mem "p50" lat_keys);
+       check bool "has p95" true (List.mem "p95" lat_keys);
+       check bool "has p99" true (List.mem "p99" lat_keys);
+       check bool "has min" true (List.mem "min" lat_keys);
+       check bool "has max" true (List.mem "max" lat_keys)
+   | _ -> fail "latency_ms not an object")
+
+let test_to_json_types () =
+  Eio_main.run @@ fun _env ->
+  let json = Server_metrics.to_json () in
+  let open Yojson.Safe.Util in
+  (* Integer fields *)
+  let _ = json |> member "inflight" |> to_int in
+  let _ = json |> member "total" |> to_int in
+  let _ = json |> member "errors" |> to_int in
+  let _ = json |> member "bytes_out" |> to_int in
+  (* Float fields *)
+  let _ = json |> member "rps_1m" |> to_float in
+  let _ = json |> member "rps_5m" |> to_float in
+  let _ = json |> member "updated_at" |> to_float in
+  ()
+
+(* ============== to_prometheus_text: format verification ============== *)
+
+let test_prometheus_header_lines () =
+  Eio_main.run @@ fun _env ->
+  let text = Server_metrics.to_prometheus_text () in
+  check bool "has HELP requests" true
+    (String.length text > 0);
+  let lines = String.split_on_char '\n' text in
+  let help_lines = List.filter (fun l ->
+    String.length l > 6 && String.sub l 0 6 = "# HELP"
+  ) lines in
+  let type_lines = List.filter (fun l ->
+    String.length l > 6 && String.sub l 0 6 = "# TYPE"
+  ) lines in
+  check bool "has HELP lines" true (List.length help_lines > 0);
+  check bool "has TYPE lines" true (List.length type_lines > 0);
+  check bool "same count" true (List.length help_lines = List.length type_lines)
+
+let test_prometheus_metric_names () =
+  Eio_main.run @@ fun _env ->
+  let text = Server_metrics.to_prometheus_text () in
+  let expected_metrics = [
+    "mcp_http_requests_total";
+    "mcp_http_inflight";
+    "mcp_http_errors_total";
+    "mcp_http_bytes_out_total";
+    "mcp_http_rps_1m";
+    "mcp_http_rps_5m";
+    "mcp_http_latency_ms";
+    "mcp_sse_open";
+    "mcp_sse_total";
+  ] in
+  List.iter (fun metric ->
+    let found = try let _ = Str.search_forward (Str.regexp_string metric) text 0 in true
+                with Not_found -> false in
+    check bool (Printf.sprintf "contains %s" metric) true found
+  ) expected_metrics
+
+let test_prometheus_status_classes () =
+  Eio_main.run @@ fun _env ->
+  let text = Server_metrics.to_prometheus_text () in
+  check bool "has 2xx class" true
+    (try let _ = Str.search_forward (Str.regexp_string "class=\"2xx\"") text 0 in true
+     with Not_found -> false);
+  check bool "has 3xx class" true
+    (try let _ = Str.search_forward (Str.regexp_string "class=\"3xx\"") text 0 in true
+     with Not_found -> false);
+  check bool "has 4xx class" true
+    (try let _ = Str.search_forward (Str.regexp_string "class=\"4xx\"") text 0 in true
+     with Not_found -> false);
+  check bool "has 5xx class" true
+    (try let _ = Str.search_forward (Str.regexp_string "class=\"5xx\"") text 0 in true
+     with Not_found -> false)
+
+let test_prometheus_quantiles () =
+  Eio_main.run @@ fun _env ->
+  let text = Server_metrics.to_prometheus_text () in
+  check bool "has p50" true
+    (try let _ = Str.search_forward (Str.regexp_string "quantile=\"0.50\"") text 0 in true
+     with Not_found -> false);
+  check bool "has p95" true
+    (try let _ = Str.search_forward (Str.regexp_string "quantile=\"0.95\"") text 0 in true
+     with Not_found -> false);
+  check bool "has p99" true
+    (try let _ = Str.search_forward (Str.regexp_string "quantile=\"0.99\"") text 0 in true
+     with Not_found -> false)
+
+(* ============== snapshot consistency after multiple operations ============== *)
+
+let test_mixed_status_codes () =
+  Eio_main.run @@ fun _env ->
+  let before = Server_metrics.snapshot () in
+  Server_metrics.record_untracked_response `OK;
+  Server_metrics.record_untracked_response `Not_found;
+  Server_metrics.record_untracked_response `Internal_server_error;
+  Server_metrics.record_untracked_response `Moved_permanently;
+  let after = Server_metrics.snapshot () in
+  check int "total+4" (before.total + 4) after.total;
+  check int "2xx+1" (before.status_2xx + 1) after.status_2xx;
+  check int "3xx+1" (before.status_3xx + 1) after.status_3xx;
+  check int "4xx+1" (before.status_4xx + 1) after.status_4xx;
+  check int "5xx+1" (before.status_5xx + 1) after.status_5xx;
+  check int "errors+2" (before.errors + 2) after.errors
+
+(* ============== rps window observable via snapshot ============== *)
+
+let test_rps_observable () =
+  Eio_main.run @@ fun _env ->
+  (* After recording requests, rps should be positive *)
+  Server_metrics.record_untracked_response `OK;
+  Server_metrics.record_untracked_response `OK;
+  Server_metrics.record_untracked_response `OK;
+  let s = Server_metrics.snapshot () in
+  (* rps_1m = sum_recent(60s) / 60.0 — should be > 0 after fresh requests *)
+  check bool "rps_1m > 0" true (s.rps_1m > 0.0);
+  check bool "rps_5m > 0" true (s.rps_5m > 0.0)
+
+let () =
+  run "server_metrics_a5"
+    [ ("prom_metric", [
+        test_case "basic format" `Quick test_prom_metric_basic;
+        test_case "empty labels" `Quick test_prom_metric_empty_labels;
+        test_case "multi labels" `Quick test_prom_metric_multi_labels;
+        test_case "float value" `Quick test_prom_metric_float_value;
+      ]);
+      ("record_untracked_2xx", [
+        test_case "2xx with bytes" `Quick test_untracked_2xx;
+        test_case "2xx no bytes" `Quick test_untracked_2xx_no_bytes;
+      ]);
+      ("record_untracked_3xx", [
+        test_case "3xx" `Quick test_untracked_3xx;
+      ]);
+      ("sse", [
+        test_case "open/close pair" `Quick test_sse_open_close_pair;
+        test_case "close no underflow" `Quick test_sse_close_no_underflow;
+      ]);
+      ("snapshot", [
+        test_case "all fields valid" `Quick test_snapshot_fields;
+        test_case "latency fields" `Quick test_snapshot_latency_fields;
+      ]);
+      ("to_json", [
+        test_case "required keys" `Quick test_to_json_keys;
+        test_case "field types" `Quick test_to_json_types;
+      ]);
+      ("to_prometheus_text", [
+        test_case "HELP/TYPE headers" `Quick test_prometheus_header_lines;
+        test_case "metric names" `Quick test_prometheus_metric_names;
+        test_case "status classes" `Quick test_prometheus_status_classes;
+        test_case "quantiles" `Quick test_prometheus_quantiles;
+      ]);
+      ("integration", [
+        test_case "mixed status codes" `Quick test_mixed_status_codes;
+        test_case "rps observable" `Quick test_rps_observable;
+      ]);
+    ]

--- a/test/test_similarity_a5.ml
+++ b/test/test_similarity_a5.ml
@@ -1,0 +1,658 @@
+(** Coverage A5 tests for figma_similarity.ml — precise numeric assertions
+    on all pure color math, IoU/GIoU/DIoU, TED, and formatting functions.
+
+    Complements existing test_similarity_effects_coverage.ml (loose range checks)
+    with exact reference values and untouched branches.
+*)
+
+open Alcotest
+
+(* ============== Test Helpers ============== *)
+
+let float_eq ?(eps=0.01) a b = Float.abs (a -. b) < eps
+
+let f eps =
+  testable (fun ppf v -> Fmt.pf ppf "%.6f" v) (float_eq ~eps)
+
+(* ============== linearize_rgb ============== *)
+
+let test_linearize_rgb_zero () =
+  let r = Figma_similarity.linearize_rgb 0.0 in
+  check (f 0.0001) "0.0 stays 0.0" 0.0 r
+
+let test_linearize_rgb_one () =
+  let r = Figma_similarity.linearize_rgb 1.0 in
+  check (f 0.0001) "1.0 stays 1.0" 1.0 r
+
+let test_linearize_rgb_below_threshold () =
+  (* 0.04045 is the threshold; 0.04 is below *)
+  let r = Figma_similarity.linearize_rgb 0.04 in
+  (* linear region: 0.04 / 12.92 = 0.003096 *)
+  check (f 0.0001) "linear region" 0.003096 r
+
+let test_linearize_rgb_above_threshold () =
+  (* 0.5: ((0.5 + 0.055) / 1.055) ^ 2.4 = 0.214041 *)
+  let r = Figma_similarity.linearize_rgb 0.5 in
+  check (f 0.001) "gamma region 0.5" 0.2140 r
+
+let test_linearize_rgb_at_threshold () =
+  (* Exactly at threshold 0.04045: linear path *)
+  let r = Figma_similarity.linearize_rgb 0.04045 in
+  check (f 0.0001) "at threshold" (0.04045 /. 12.92) r
+
+(* ============== rgb_to_xyz ============== *)
+
+let test_rgb_to_xyz_black () =
+  let (x, y, z) = Figma_similarity.rgb_to_xyz (0.0, 0.0, 0.0) in
+  check (f 0.0001) "black X" 0.0 x;
+  check (f 0.0001) "black Y" 0.0 y;
+  check (f 0.0001) "black Z" 0.0 z
+
+let test_rgb_to_xyz_white () =
+  let (x, y, z) = Figma_similarity.rgb_to_xyz (1.0, 1.0, 1.0) in
+  (* D65 white point: X=0.95047, Y=1.0, Z=1.08883 *)
+  check (f 0.005) "white X" 0.9505 x;
+  check (f 0.005) "white Y" 1.0 y;
+  check (f 0.005) "white Z" 1.0888 z
+
+let test_rgb_to_xyz_red () =
+  let (x, y, z) = Figma_similarity.rgb_to_xyz (1.0, 0.0, 0.0) in
+  (* sRGB red: X=0.4124, Y=0.2127, Z=0.0193 *)
+  check (f 0.005) "red X" 0.4125 x;
+  check (f 0.005) "red Y" 0.2127 y;
+  check (f 0.005) "red Z" 0.0193 z
+
+(* ============== xyz_to_lab ============== *)
+
+let test_xyz_to_lab_d65_white () =
+  (* D65 white point -> Lab(100, 0, 0) *)
+  let (l, a, b) = Figma_similarity.xyz_to_lab (0.95047, 1.0, 1.08883) in
+  check (f 0.1) "white L" 100.0 l;
+  check (f 0.1) "white a" 0.0 a;
+  check (f 0.1) "white b" 0.0 b
+
+let test_xyz_to_lab_black () =
+  let (l, _a, _b) = Figma_similarity.xyz_to_lab (0.0, 0.0, 0.0) in
+  check (f 0.1) "black L" 0.0 l
+
+let test_xyz_to_lab_below_threshold () =
+  (* t <= 0.008856 triggers linear branch: (903.3 * t + 16) / 116 *)
+  let (l, _a, _b) = Figma_similarity.xyz_to_lab (0.001, 0.001, 0.001) in
+  check bool "very dark L < 1" true (l < 1.0 && l >= 0.0)
+
+(* ============== rgb_to_lab ============== *)
+
+let test_rgb_to_lab_black () =
+  let (l, _a, _b) = Figma_similarity.rgb_to_lab (0.0, 0.0, 0.0) in
+  check (f 0.1) "black L" 0.0 l
+
+let test_rgb_to_lab_white () =
+  let (l, a, b) = Figma_similarity.rgb_to_lab (1.0, 1.0, 1.0) in
+  check (f 0.5) "white L" 100.0 l;
+  check (f 0.5) "white a" 0.0 a;
+  check (f 0.5) "white b" 0.0 b
+
+let test_rgb_to_lab_red () =
+  (* sRGB red -> Lab ~(53.23, 80.11, 67.22) *)
+  let (l, a, b) = Figma_similarity.rgb_to_lab (1.0, 0.0, 0.0) in
+  check (f 1.0) "red L" 53.23 l;
+  check (f 1.0) "red a" 80.11 a;
+  check (f 1.0) "red b" 67.22 b
+
+(* ============== linear_rgb_to_oklab ============== *)
+
+let test_linear_rgb_to_oklab_black () =
+  let (l, a, b) = Figma_similarity.linear_rgb_to_oklab (0.0, 0.0, 0.0) in
+  check (f 0.001) "black L" 0.0 l;
+  check (f 0.001) "black a" 0.0 a;
+  check (f 0.001) "black b" 0.0 b
+
+let test_linear_rgb_to_oklab_white () =
+  (* linear white (1,1,1) -> OKLab (1, 0, 0) *)
+  let (l, a, b) = Figma_similarity.linear_rgb_to_oklab (1.0, 1.0, 1.0) in
+  check (f 0.001) "white L" 1.0 l;
+  check (f 0.001) "white a" 0.0 a;
+  check (f 0.001) "white b" 0.0 b
+
+(* ============== rgb_to_oklab ============== *)
+
+let test_rgb_to_oklab_red () =
+  (* sRGB red -> OKLab ~(0.628, 0.225, 0.126) *)
+  let (l, a, b) = Figma_similarity.rgb_to_oklab (1.0, 0.0, 0.0) in
+  check (f 0.005) "red L" 0.6280 l;
+  check (f 0.005) "red a" 0.2249 a;
+  check (f 0.005) "red b" 0.1260 b
+
+let test_rgb_to_oklab_blue () =
+  (* sRGB blue -> OKLab ~(0.452, -0.032, -0.312) *)
+  let (l, a, b) = Figma_similarity.rgb_to_oklab (0.0, 0.0, 1.0) in
+  check (f 0.005) "blue L" 0.4520 l;
+  check (f 0.005) "blue a" (-0.0324) a;
+  check (f 0.005) "blue b" (-0.3115) b
+
+let test_rgb_to_oklab_50_gray () =
+  let (l, a, b) = Figma_similarity.rgb_to_oklab (0.5, 0.5, 0.5) in
+  check (f 0.005) "gray L" 0.5982 l;
+  check (f 0.001) "gray a" 0.0 a;
+  check (f 0.001) "gray b" 0.0 b
+
+(* ============== oklab_distance ============== *)
+
+let test_oklab_distance_same () =
+  let d = Figma_similarity.oklab_distance (0.5, 0.1, -0.1) (0.5, 0.1, -0.1) in
+  check (f 0.0001) "same color" 0.0 d
+
+let test_oklab_distance_L_only () =
+  (* Only L differs: sqrt((1.0-0.0)^2) = 1.0 *)
+  let d = Figma_similarity.oklab_distance (0.0, 0.0, 0.0) (1.0, 0.0, 0.0) in
+  check (f 0.0001) "L axis only" 1.0 d
+
+let test_oklab_distance_a_only () =
+  (* sqrt(0.5^2) = 0.5 *)
+  let d = Figma_similarity.oklab_distance (0.5, 0.0, 0.0) (0.5, 0.5, 0.0) in
+  check (f 0.0001) "a axis only" 0.5 d
+
+(* ============== color_distance_oklab ============== *)
+
+let test_color_distance_oklab_same () =
+  let d = Figma_similarity.color_distance_oklab (1.0, 0.0, 0.0) (1.0, 0.0, 0.0) in
+  check (f 0.0001) "same color" 0.0 d
+
+let test_color_distance_oklab_bw () =
+  let d = Figma_similarity.color_distance_oklab (0.0, 0.0, 0.0) (1.0, 1.0, 1.0) in
+  check (f 0.05) "black-white" 1.0 d
+
+(* ============== rgba_distance_oklab ============== *)
+
+let test_rgba_distance_oklab_same () =
+  let open Figma_types in
+  let c : rgba = { r = 0.5; g = 0.3; b = 0.8; a = 1.0 } in
+  let d = Figma_similarity.rgba_distance_oklab c c in
+  check (f 0.0001) "same rgba" 0.0 d
+
+let test_rgba_distance_oklab_different () =
+  let open Figma_types in
+  let c1 : rgba = { r = 1.0; g = 0.0; b = 0.0; a = 1.0 } in
+  let c2 : rgba = { r = 0.0; g = 0.0; b = 1.0; a = 1.0 } in
+  let d = Figma_similarity.rgba_distance_oklab c1 c2 in
+  check bool "red-blue positive" true (d > 0.0)
+
+(* ============== oklab_to_similarity ============== *)
+
+let test_oklab_to_similarity_zero () =
+  let s = Figma_similarity.oklab_to_similarity 0.0 in
+  check (f 0.01) "0 dist -> 100%" 100.0 s
+
+let test_oklab_to_similarity_jnd () =
+  (* 0.02 JND: 100 * exp(-0.02 * 10) = 100 * exp(-0.2) = 81.87 *)
+  let s = Figma_similarity.oklab_to_similarity 0.02 in
+  check (f 0.5) "JND distance" 81.87 s
+
+let test_oklab_to_similarity_large () =
+  let s = Figma_similarity.oklab_to_similarity 1.0 in
+  (* 100 * exp(-10) = 0.00454 *)
+  check bool "large dist near 0" true (s < 0.01)
+
+(* ============== ciede2000 ============== *)
+
+let test_ciede2000_same_color () =
+  let de = Figma_similarity.ciede2000 (50.0, 25.0, -10.0) (50.0, 25.0, -10.0) in
+  check (f 0.0001) "same color" 0.0 de
+
+let test_ciede2000_sharma_pair_1 () =
+  (* Sharma et al. 2005, test pair 1 *)
+  let de = Figma_similarity.ciede2000
+    (50.0, 2.6772, -79.7751) (50.0, 0.0, -82.7485) in
+  check (f 0.001) "Sharma pair 1" 2.0425 de
+
+let test_ciede2000_sharma_pair_4 () =
+  (* Sharma pair 4: expected 1.0 *)
+  let de = Figma_similarity.ciede2000
+    (50.0, -1.3802, -84.2814) (50.0, 0.0, -82.7485) in
+  check (f 0.001) "Sharma pair 4" 1.0 de
+
+let test_ciede2000_sharma_pair_7 () =
+  (* Achromatic case: both near zero chroma *)
+  let de = Figma_similarity.ciede2000
+    (50.0, 0.0, 0.0) (50.0, -1.0, 2.0) in
+  check (f 0.001) "Sharma pair 7" 2.3669 de
+
+let test_ciede2000_sharma_pair_9 () =
+  (* Near-achromatic hue angle wrap *)
+  let de = Figma_similarity.ciede2000
+    (50.0, 2.49, -0.001) (50.0, -2.49, 0.0009) in
+  check (f 0.001) "Sharma pair 9" 7.1792 de
+
+let test_ciede2000_sharma_pair_17 () =
+  (* Large L difference *)
+  let de = Figma_similarity.ciede2000
+    (50.0, 2.5, 0.0) (73.0, 25.0, -18.0) in
+  check (f 0.001) "Sharma pair 17" 27.1492 de
+
+let test_ciede2000_sharma_pair_25 () =
+  let de = Figma_similarity.ciede2000
+    (60.2574, -34.0099, 36.2677) (60.4626, -34.1751, 39.4387) in
+  check (f 0.001) "Sharma pair 25" 1.2644 de
+
+let test_ciede2000_achromatic_both () =
+  (* Both a=0, b=0: achromatic, h' forced to 0, delta_h'=0 *)
+  let de = Figma_similarity.ciede2000 (50.0, 0.0, 0.0) (60.0, 0.0, 0.0) in
+  check bool "achromatic L-only diff" true (de > 0.0)
+
+let test_ciede2000_hue_wrap_gt180 () =
+  (* h2' - h1' > 180: triggers dh - 360 branch *)
+  let de = Figma_similarity.ciede2000
+    (50.0, 2.5, 0.0) (50.0, 0.0, -2.5) in
+  check (f 0.001) "hue wrap >180" 4.3065 de
+
+let test_ciede2000_weighted () =
+  let de_default = Figma_similarity.ciede2000
+    (50.0, 10.0, 0.0) (60.0, 10.0, 0.0) in
+  let de_kl2 = Figma_similarity.ciede2000 ~kl:2.0
+    (50.0, 10.0, 0.0) (60.0, 10.0, 0.0) in
+  check bool "kL=2 reduces L impact" true (de_kl2 < de_default)
+
+let test_ciede2000_kc_weight () =
+  let de_default = Figma_similarity.ciede2000
+    (50.0, 30.0, 0.0) (50.0, 10.0, 0.0) in
+  let de_kc2 = Figma_similarity.ciede2000 ~kc:2.0
+    (50.0, 30.0, 0.0) (50.0, 10.0, 0.0) in
+  check bool "kC=2 reduces C impact" true (de_kc2 < de_default)
+
+(* ============== color_distance_ciede2000 ============== *)
+
+let test_color_distance_ciede2000_same () =
+  let de = Figma_similarity.color_distance_ciede2000 (0.5, 0.5, 0.5) (0.5, 0.5, 0.5) in
+  check (f 0.0001) "same gray" 0.0 de
+
+let test_color_distance_ciede2000_rg () =
+  let de = Figma_similarity.color_distance_ciede2000 (1.0, 0.0, 0.0) (0.0, 1.0, 0.0) in
+  check bool "red-green large delta" true (de > 50.0)
+
+(* ============== rgba_distance_ciede2000 ============== *)
+
+let test_rgba_distance_ciede2000_same () =
+  let open Figma_types in
+  let c : rgba = { r = 0.5; g = 0.5; b = 0.5; a = 1.0 } in
+  let de = Figma_similarity.rgba_distance_ciede2000 c c in
+  check (f 0.0001) "same rgba" 0.0 de
+
+(* ============== delta_e_to_similarity ============== *)
+
+let test_delta_e_to_similarity_zero () =
+  let s = Figma_similarity.delta_e_to_similarity 0.0 in
+  check (f 0.01) "0 -> 100%" 100.0 s
+
+let test_delta_e_to_similarity_50 () =
+  (* 100 * exp(-50/50) = 100 * exp(-1) = 36.79 *)
+  let s = Figma_similarity.delta_e_to_similarity 50.0 in
+  check (f 0.5) "50 -> ~36.8%" 36.79 s
+
+let test_delta_e_to_similarity_100 () =
+  (* 100 * exp(-100/50) = 100 * exp(-2) = 13.53 *)
+  let s = Figma_similarity.delta_e_to_similarity 100.0 in
+  check (f 0.5) "100 -> ~13.5%" 13.53 s
+
+(* ============== IoU ============== *)
+
+let test_iou_identical () =
+  let v = Figma_similarity.iou (10.0, 20.0, 50.0, 60.0) (10.0, 20.0, 50.0, 60.0) in
+  check (f 0.0001) "identical" 1.0 v
+
+let test_iou_no_overlap () =
+  let v = Figma_similarity.iou (0.0, 0.0, 10.0, 10.0) (100.0, 100.0, 10.0, 10.0) in
+  check (f 0.0001) "no overlap" 0.0 v
+
+let test_iou_partial () =
+  (* (0,0,100,100) and (50,0,100,100): intersection 50x100=5000, union 15000 *)
+  let v = Figma_similarity.iou (0.0, 0.0, 100.0, 100.0) (50.0, 0.0, 100.0, 100.0) in
+  check (f 0.001) "partial overlap" (1.0 /. 3.0) v
+
+let test_iou_zero_area () =
+  let v = Figma_similarity.iou (0.0, 0.0, 0.0, 0.0) (0.0, 0.0, 0.0, 0.0) in
+  check (f 0.0001) "zero area" 0.0 v
+
+let test_iou_contained () =
+  (* (25,25,50,50) fully inside (0,0,100,100) *)
+  (* intersection=2500, union=10000+2500-2500=10000 -> 0.25 *)
+  let v = Figma_similarity.iou (0.0, 0.0, 100.0, 100.0) (25.0, 25.0, 50.0, 50.0) in
+  check (f 0.001) "contained" 0.25 v
+
+(* ============== GIoU ============== *)
+
+let test_giou_identical () =
+  let v = Figma_similarity.giou (0.0, 0.0, 100.0, 100.0) (0.0, 0.0, 100.0, 100.0) in
+  check (f 0.0001) "identical" 1.0 v
+
+let test_giou_no_overlap_negative () =
+  let v = Figma_similarity.giou (0.0, 0.0, 50.0, 50.0) (100.0, 100.0, 50.0, 50.0) in
+  check bool "non-overlapping negative" true (v < 0.0)
+
+let test_giou_zero_area () =
+  let v = Figma_similarity.giou (0.0, 0.0, 0.0, 0.0) (0.0, 0.0, 0.0, 0.0) in
+  check (f 0.0001) "zero area" 0.0 v
+
+let test_giou_to_similarity_max () =
+  check (f 0.01) "1.0 -> 100%" 100.0 (Figma_similarity.giou_to_similarity 1.0)
+
+let test_giou_to_similarity_min () =
+  check (f 0.01) "-1.0 -> 0%" 0.0 (Figma_similarity.giou_to_similarity (-1.0))
+
+let test_giou_to_similarity_mid () =
+  check (f 0.01) "0.0 -> 50%" 50.0 (Figma_similarity.giou_to_similarity 0.0)
+
+(* ============== DIoU ============== *)
+
+let test_diou_identical () =
+  let v = Figma_similarity.diou (0.0, 0.0, 100.0, 100.0) (0.0, 0.0, 100.0, 100.0) in
+  check (f 0.0001) "identical" 1.0 v
+
+let test_diou_offset () =
+  let v = Figma_similarity.diou (0.0, 0.0, 100.0, 100.0) (50.0, 50.0, 100.0, 100.0) in
+  check bool "offset < 1" true (v < 1.0 && v > -1.0)
+
+let test_diou_zero_diagonal () =
+  (* Both zero-area boxes at same point -> c2=0, returns iou_val *)
+  let v = Figma_similarity.diou (5.0, 5.0, 0.0, 0.0) (5.0, 5.0, 0.0, 0.0) in
+  check (f 0.0001) "zero diagonal" 0.0 v
+
+let test_diou_to_similarity_max () =
+  check (f 0.01) "1.0 -> 100%" 100.0 (Figma_similarity.diou_to_similarity 1.0)
+
+let test_diou_to_similarity_min () =
+  check (f 0.01) "-1.0 -> 0%" 0.0 (Figma_similarity.diou_to_similarity (-1.0))
+
+(* ============== node_iou / node_giou / node_diou with None bbox ============== *)
+
+let test_node_giou_no_bbox () =
+  let open Figma_types in
+  let n1 = { default_node with bbox = None } in
+  let n2 = { default_node with bbox = Some { x = 0.0; y = 0.0; width = 10.0; height = 10.0 } } in
+  let v = Figma_similarity.node_giou n1 n2 in
+  check (f 0.0001) "one None" 0.0 v
+
+let test_node_diou_no_bbox () =
+  let open Figma_types in
+  let n = { default_node with bbox = None } in
+  let v = Figma_similarity.node_diou n n in
+  check (f 0.0001) "both None" 0.0 v
+
+(* ============== Tree Edit Distance ============== *)
+
+let test_ted_leaf_same_type () =
+  let open Figma_types in
+  let n = { default_node with node_type = Text; children = [] } in
+  check int "same leaf" 0 (Figma_similarity.tree_edit_distance n n)
+
+let test_ted_leaf_different_type () =
+  let open Figma_types in
+  let n1 = { default_node with node_type = Frame; children = [] } in
+  let n2 = { default_node with node_type = Text; children = [] } in
+  check int "different leaf" 1 (Figma_similarity.tree_edit_distance n1 n2)
+
+let test_ted_one_has_children () =
+  let open Figma_types in
+  let child1 = { default_node with node_type = Text; children = [] } in
+  let child2 = { default_node with node_type = Rectangle; children = [] } in
+  let n1 = { default_node with node_type = Frame; children = [child1; child2] } in
+  let n2 = { default_node with node_type = Frame; children = [] } in
+  (* label_cost=0, n2=0 children -> cost = 0 + 2 *)
+  check int "n2 has no children" 2 (Figma_similarity.tree_edit_distance n1 n2)
+
+let test_ted_other_has_children () =
+  let open Figma_types in
+  let child = { default_node with node_type = Text; children = [] } in
+  let n1 = { default_node with node_type = Frame; children = [] } in
+  let n2 = { default_node with node_type = Frame; children = [child; child; child] } in
+  (* label_cost=0, n1=0 children -> cost = 0 + 3 *)
+  check int "n1 has no children" 3 (Figma_similarity.tree_edit_distance n1 n2)
+
+let test_ted_dp_matching () =
+  let open Figma_types in
+  let text = { default_node with node_type = Text; children = [] } in
+  let rect = { default_node with node_type = Rectangle; children = [] } in
+  let n1 = { default_node with node_type = Frame; children = [text; rect] } in
+  let n2 = { default_node with node_type = Frame; children = [rect; text] } in
+  (* Swap: each child needs 1 replace -> DP picks min 2 *)
+  check int "swapped children" 2 (Figma_similarity.tree_edit_distance n1 n2)
+
+let test_ted_to_similarity_zero () =
+  check (f 0.01) "0/10" 100.0 (Figma_similarity.ted_to_similarity 0 10)
+
+let test_ted_to_similarity_full () =
+  check (f 0.01) "10/10" 0.0 (Figma_similarity.ted_to_similarity 10 10)
+
+let test_ted_to_similarity_zero_max () =
+  check (f 0.01) "0/0" 100.0 (Figma_similarity.ted_to_similarity 0 0)
+
+(* ============== metrics_to_string formatting branches ============== *)
+
+let test_metrics_to_string_jnd_below () =
+  let m : Figma_similarity.similarity_metrics = {
+    color_delta_e = 1.5;  (* < 2.3 JND *)
+    color_similarity = 97.0;
+    layout_iou = 0.9; layout_similarity = 90.0;
+    structure_ted = 0; structure_similarity = 100.0;
+    overall_similarity = 95.0;
+  } in
+  let s = Figma_similarity.metrics_to_string m in
+  check bool "contains JND annotation" true (String.length s > 0)
+
+let test_metrics_to_string_slight () =
+  let m : Figma_similarity.similarity_metrics = {
+    color_delta_e = 3.0;  (* 2.3..5.0 *)
+    color_similarity = 94.0;
+    layout_iou = 0.8; layout_similarity = 80.0;
+    structure_ted = 1; structure_similarity = 90.0;
+    overall_similarity = 88.0;
+  } in
+  let s = Figma_similarity.metrics_to_string m in
+  check bool "non-empty output" true (String.length s > 100)
+
+let test_metrics_to_string_large_de () =
+  let m : Figma_similarity.similarity_metrics = {
+    color_delta_e = 50.0;  (* >= 5.0, no annotation *)
+    color_similarity = 37.0;
+    layout_iou = 0.1; layout_similarity = 10.0;
+    structure_ted = 5; structure_similarity = 50.0;
+    overall_similarity = 30.0;
+  } in
+  let s = Figma_similarity.metrics_to_string m in
+  check bool "no annotation" true (String.length s > 100)
+
+(* ============== extended_color_to_string branches ============== *)
+
+let test_extended_color_to_string_identical () =
+  let m = Figma_similarity.compute_extended_color_metrics
+    (0.5, 0.5, 0.5) (0.5, 0.5, 0.5) in
+  let s = Figma_similarity.extended_color_to_string m in
+  check bool "has table" true (String.length s > 50)
+
+let test_extended_color_to_string_different () =
+  let m = Figma_similarity.compute_extended_color_metrics
+    (1.0, 0.0, 0.0) (0.0, 0.0, 1.0) in
+  let s = Figma_similarity.extended_color_to_string m in
+  check bool "has table" true (String.length s > 50)
+
+(* ============== extended_box_to_string IoU annotation branches ============== *)
+
+let test_extended_box_to_string_perfect () =
+  let m = Figma_similarity.compute_extended_box_metrics
+    (0.0, 0.0, 100.0, 100.0) (0.0, 0.0, 100.0, 100.0) in
+  let s = Figma_similarity.extended_box_to_string m in
+  check bool "iou >= 0.9 branch" true (String.length s > 50)
+
+let test_extended_box_to_string_partial () =
+  let m = Figma_similarity.compute_extended_box_metrics
+    (0.0, 0.0, 100.0, 100.0) (25.0, 25.0, 100.0, 100.0) in
+  let s = Figma_similarity.extended_box_to_string m in
+  check bool "partial overlap" true (String.length s > 50)
+
+let test_extended_box_to_string_none () =
+  let m = Figma_similarity.compute_extended_box_metrics
+    (0.0, 0.0, 10.0, 10.0) (100.0, 100.0, 10.0, 10.0) in
+  let s = Figma_similarity.extended_box_to_string m in
+  check bool "no overlap" true (String.length s > 50)
+
+(* ============== rgba_to_lab ============== *)
+
+let test_rgba_to_lab_black () =
+  let open Figma_types in
+  let c : rgba = { r = 0.0; g = 0.0; b = 0.0; a = 1.0 } in
+  let (l, _a, _b) = Figma_similarity.rgba_to_lab c in
+  check (f 0.1) "black L" 0.0 l
+
+(* ============== compute_extended_color_metrics ============== *)
+
+let test_extended_color_metrics_rgb_euclidean () =
+  let m = Figma_similarity.compute_extended_color_metrics
+    (1.0, 0.0, 0.0) (0.0, 1.0, 0.0) in
+  (* sqrt(1+1) = 1.414 *)
+  check (f 0.01) "rg euclidean" 1.414 m.rgb_euclidean
+
+(* ============== compute_extended_box_metrics ============== *)
+
+let test_extended_box_metrics_center_distance () =
+  let m = Figma_similarity.compute_extended_box_metrics
+    (0.0, 0.0, 100.0, 100.0) (100.0, 0.0, 100.0, 100.0) in
+  (* centers: (50,50) and (150,50), distance=100 *)
+  check (f 0.01) "center dist" 100.0 m.center_distance
+
+(* ============== Test Runner ============== *)
+
+let () =
+  run "Similarity A5" [
+    ("linearize_rgb", [
+      test_case "zero" `Quick test_linearize_rgb_zero;
+      test_case "one" `Quick test_linearize_rgb_one;
+      test_case "below threshold" `Quick test_linearize_rgb_below_threshold;
+      test_case "above threshold" `Quick test_linearize_rgb_above_threshold;
+      test_case "at threshold" `Quick test_linearize_rgb_at_threshold;
+    ]);
+    ("rgb_to_xyz", [
+      test_case "black" `Quick test_rgb_to_xyz_black;
+      test_case "white" `Quick test_rgb_to_xyz_white;
+      test_case "red" `Quick test_rgb_to_xyz_red;
+    ]);
+    ("xyz_to_lab", [
+      test_case "D65 white" `Quick test_xyz_to_lab_d65_white;
+      test_case "black" `Quick test_xyz_to_lab_black;
+      test_case "below threshold" `Quick test_xyz_to_lab_below_threshold;
+    ]);
+    ("rgb_to_lab", [
+      test_case "black" `Quick test_rgb_to_lab_black;
+      test_case "white" `Quick test_rgb_to_lab_white;
+      test_case "red" `Quick test_rgb_to_lab_red;
+    ]);
+    ("linear_rgb_to_oklab", [
+      test_case "black" `Quick test_linear_rgb_to_oklab_black;
+      test_case "white" `Quick test_linear_rgb_to_oklab_white;
+    ]);
+    ("rgb_to_oklab", [
+      test_case "red" `Quick test_rgb_to_oklab_red;
+      test_case "blue" `Quick test_rgb_to_oklab_blue;
+      test_case "50% gray" `Quick test_rgb_to_oklab_50_gray;
+    ]);
+    ("oklab_distance", [
+      test_case "same" `Quick test_oklab_distance_same;
+      test_case "L only" `Quick test_oklab_distance_L_only;
+      test_case "a only" `Quick test_oklab_distance_a_only;
+    ]);
+    ("color_distance_oklab", [
+      test_case "same" `Quick test_color_distance_oklab_same;
+      test_case "black-white" `Quick test_color_distance_oklab_bw;
+    ]);
+    ("rgba_distance_oklab", [
+      test_case "same" `Quick test_rgba_distance_oklab_same;
+      test_case "different" `Quick test_rgba_distance_oklab_different;
+    ]);
+    ("oklab_to_similarity", [
+      test_case "zero" `Quick test_oklab_to_similarity_zero;
+      test_case "JND" `Quick test_oklab_to_similarity_jnd;
+      test_case "large" `Quick test_oklab_to_similarity_large;
+    ]);
+    ("ciede2000", [
+      test_case "same color" `Quick test_ciede2000_same_color;
+      test_case "Sharma pair 1" `Quick test_ciede2000_sharma_pair_1;
+      test_case "Sharma pair 4" `Quick test_ciede2000_sharma_pair_4;
+      test_case "Sharma pair 7" `Quick test_ciede2000_sharma_pair_7;
+      test_case "Sharma pair 9" `Quick test_ciede2000_sharma_pair_9;
+      test_case "Sharma pair 17" `Quick test_ciede2000_sharma_pair_17;
+      test_case "Sharma pair 25" `Quick test_ciede2000_sharma_pair_25;
+      test_case "achromatic both" `Quick test_ciede2000_achromatic_both;
+      test_case "hue wrap >180" `Quick test_ciede2000_hue_wrap_gt180;
+      test_case "kL weighted" `Quick test_ciede2000_weighted;
+      test_case "kC weighted" `Quick test_ciede2000_kc_weight;
+    ]);
+    ("color_distance_ciede2000", [
+      test_case "same" `Quick test_color_distance_ciede2000_same;
+      test_case "red-green" `Quick test_color_distance_ciede2000_rg;
+    ]);
+    ("rgba_distance_ciede2000", [
+      test_case "same" `Quick test_rgba_distance_ciede2000_same;
+    ]);
+    ("delta_e_to_similarity", [
+      test_case "zero" `Quick test_delta_e_to_similarity_zero;
+      test_case "50" `Quick test_delta_e_to_similarity_50;
+      test_case "100" `Quick test_delta_e_to_similarity_100;
+    ]);
+    ("iou", [
+      test_case "identical" `Quick test_iou_identical;
+      test_case "no overlap" `Quick test_iou_no_overlap;
+      test_case "partial" `Quick test_iou_partial;
+      test_case "zero area" `Quick test_iou_zero_area;
+      test_case "contained" `Quick test_iou_contained;
+    ]);
+    ("giou", [
+      test_case "identical" `Quick test_giou_identical;
+      test_case "negative" `Quick test_giou_no_overlap_negative;
+      test_case "zero area" `Quick test_giou_zero_area;
+      test_case "sim max" `Quick test_giou_to_similarity_max;
+      test_case "sim min" `Quick test_giou_to_similarity_min;
+      test_case "sim mid" `Quick test_giou_to_similarity_mid;
+    ]);
+    ("diou", [
+      test_case "identical" `Quick test_diou_identical;
+      test_case "offset" `Quick test_diou_offset;
+      test_case "zero diagonal" `Quick test_diou_zero_diagonal;
+      test_case "sim max" `Quick test_diou_to_similarity_max;
+      test_case "sim min" `Quick test_diou_to_similarity_min;
+    ]);
+    ("node bbox None", [
+      test_case "node_giou no bbox" `Quick test_node_giou_no_bbox;
+      test_case "node_diou no bbox" `Quick test_node_diou_no_bbox;
+    ]);
+    ("tree_edit_distance", [
+      test_case "same leaf" `Quick test_ted_leaf_same_type;
+      test_case "different leaf" `Quick test_ted_leaf_different_type;
+      test_case "n2 empty" `Quick test_ted_one_has_children;
+      test_case "n1 empty" `Quick test_ted_other_has_children;
+      test_case "DP matching" `Quick test_ted_dp_matching;
+      test_case "sim 0/10" `Quick test_ted_to_similarity_zero;
+      test_case "sim 10/10" `Quick test_ted_to_similarity_full;
+      test_case "sim 0/0" `Quick test_ted_to_similarity_zero_max;
+    ]);
+    ("metrics_to_string", [
+      test_case "JND below" `Quick test_metrics_to_string_jnd_below;
+      test_case "slight diff" `Quick test_metrics_to_string_slight;
+      test_case "large delta" `Quick test_metrics_to_string_large_de;
+    ]);
+    ("extended_color_to_string", [
+      test_case "identical" `Quick test_extended_color_to_string_identical;
+      test_case "different" `Quick test_extended_color_to_string_different;
+    ]);
+    ("extended_box_to_string", [
+      test_case "perfect overlap" `Quick test_extended_box_to_string_perfect;
+      test_case "partial overlap" `Quick test_extended_box_to_string_partial;
+      test_case "no overlap" `Quick test_extended_box_to_string_none;
+    ]);
+    ("rgba_to_lab", [
+      test_case "black" `Quick test_rgba_to_lab_black;
+    ]);
+    ("extended_color_metrics", [
+      test_case "rgb euclidean" `Quick test_extended_color_metrics_rgb_euclidean;
+    ]);
+    ("extended_box_metrics", [
+      test_case "center distance" `Quick test_extended_box_metrics_center_distance;
+    ]);
+  ]

--- a/test/test_tools_a5.ml
+++ b/test/test_tools_a5.ml
@@ -1,0 +1,1053 @@
+(** Coverage A5 push: mcp_tools.ml handler functions.
+    Targets 270 uncovered points across:
+    - handle_parse_url (pure)
+    - handle_get_me (effect)
+    - handle_list_projects (effect)
+    - handle_list_files (effect)
+    - handle_cache_stats (pure)
+    - handle_cache_invalidate (pure)
+    - handle_doctor (pure, system-dependent)
+    - handle_read_large_result (pure, file I/O)
+    - handle_codegen_sync (pure)
+    - handle_category (pure dispatch)
+    - handle_get_variables (effect)
+    - handle_query (effect)
+    - handle_search (effect)
+    - handle_tree (effect)
+    - handle_stats (effect)
+    - handle_export_tokens (effect)
+    - handle_team_tree (effect)
+    - handle_export_team (effect)
+*)
+
+open Alcotest
+
+(* ============================================================
+   Group 1: handle_parse_url — pure URL parsing
+   ============================================================ *)
+
+let test_parse_url_design_url () =
+  let args = `Assoc [("url", `String "https://www.figma.com/design/ABC123/My-File?node-id=1:2")] in
+  match Mcp_tools.handle_parse_url args with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "has file_key" true (String.length text > 0);
+    check bool "contains ABC123" true
+      (try let _ = Str.search_forward (Str.regexp_string "ABC123") text 0 in true with Not_found -> false);
+    check bool "contains node_id" true
+      (try let _ = Str.search_forward (Str.regexp_string "1:2") text 0 in true with Not_found -> false)
+  | Error msg -> fail ("Unexpected error: " ^ msg)
+
+let test_parse_url_file_url () =
+  let args = `Assoc [("url", `String "https://www.figma.com/file/XYZ789/Some-File")] in
+  match Mcp_tools.handle_parse_url args with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "contains XYZ789" true
+      (try let _ = Str.search_forward (Str.regexp_string "XYZ789") text 0 in true with Not_found -> false)
+  | Error msg -> fail ("Unexpected error: " ^ msg)
+
+let test_parse_url_team_url () =
+  let args = `Assoc [("url", `String "https://www.figma.com/files/team/TEAM42/project/PROJ99")] in
+  match Mcp_tools.handle_parse_url args with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "contains TEAM42" true
+      (try let _ = Str.search_forward (Str.regexp_string "TEAM42") text 0 in true with Not_found -> false);
+    check bool "contains PROJ99" true
+      (try let _ = Str.search_forward (Str.regexp_string "PROJ99") text 0 in true with Not_found -> false)
+  | Error msg -> fail ("Unexpected error: " ^ msg)
+
+let test_parse_url_proto_url () =
+  let args = `Assoc [("url", `String "https://www.figma.com/proto/PROTO1/Prototype?node-id=5:10")] in
+  match Mcp_tools.handle_parse_url args with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "contains PROTO1" true
+      (try let _ = Str.search_forward (Str.regexp_string "PROTO1") text 0 in true with Not_found -> false);
+    check bool "contains 5:10" true
+      (try let _ = Str.search_forward (Str.regexp_string "5:10") text 0 in true with Not_found -> false)
+  | Error msg -> fail ("Unexpected error: " ^ msg)
+
+let test_parse_url_invalid_url () =
+  let args = `Assoc [("url", `String "https://example.com/not-figma")] in
+  match Mcp_tools.handle_parse_url args with
+  | Ok json ->
+    (* Still returns Ok with (none) for all fields *)
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "has (none)" true
+      (try let _ = Str.search_forward (Str.regexp_string "(none)") text 0 in true with Not_found -> false)
+  | Error _ -> fail "Should return Ok with (none) fields"
+
+let test_parse_url_missing_url () =
+  let args = `Assoc [] in
+  match Mcp_tools.handle_parse_url args with
+  | Error msg ->
+    check bool "missing url error" true
+      (try let _ = Str.search_forward (Str.regexp_string "url") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error for missing url"
+
+let test_parse_url_no_node_id () =
+  let args = `Assoc [("url", `String "https://www.figma.com/design/KEY1/File")] in
+  match Mcp_tools.handle_parse_url args with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "node_id is (none)" true
+      (try let _ = Str.search_forward (Str.regexp_string "node_id: (none)") text 0 in true with Not_found -> false)
+  | Error msg -> fail msg
+
+(* ============================================================
+   Group 2: handle_cache_stats and handle_cache_invalidate — pure
+   ============================================================ *)
+
+let test_cache_stats () =
+  match Mcp_tools.handle_cache_stats `Null with
+  | Ok json ->
+    (* cache stats returns `Assoc with l1_entries, l2_entries, etc. *)
+    (match json with
+     | `Assoc fields ->
+       check bool "has l1_entries" true (List.mem_assoc "l1_entries" fields)
+     | _ -> ())
+  | Error msg -> fail ("Unexpected error: " ^ msg)
+
+let test_cache_invalidate_all () =
+  match Mcp_tools.handle_cache_invalidate (`Assoc []) with
+  | Ok json ->
+    let status = Yojson.Safe.Util.(json |> member "status" |> to_string) in
+    let message = Yojson.Safe.Util.(json |> member "message" |> to_string) in
+    check string "status ok" "ok" status;
+    check bool "all invalidated" true
+      (try let _ = Str.search_forward (Str.regexp_string "All") message 0 in true with Not_found -> false)
+  | Error msg -> fail msg
+
+let test_cache_invalidate_file_key () =
+  match Mcp_tools.handle_cache_invalidate (`Assoc [("file_key", `String "test-file-key")]) with
+  | Ok json ->
+    let message = Yojson.Safe.Util.(json |> member "message" |> to_string) in
+    check bool "contains file key" true
+      (try let _ = Str.search_forward (Str.regexp_string "test-file-key") message 0 in true with Not_found -> false)
+  | Error msg -> fail msg
+
+let test_cache_invalidate_file_and_node () =
+  match Mcp_tools.handle_cache_invalidate (`Assoc [("file_key", `String "fk1"); ("node_id", `String "1:2")]) with
+  | Ok json ->
+    let message = Yojson.Safe.Util.(json |> member "message" |> to_string) in
+    check bool "contains fk1/1:2" true
+      (try let _ = Str.search_forward (Str.regexp_string "fk1/1:2") message 0 in true with Not_found -> false)
+  | Error msg -> fail msg
+
+(* ============================================================
+   Group 3: handle_doctor — system checks (results vary)
+   ============================================================ *)
+
+let test_doctor () =
+  match Mcp_tools.handle_doctor `Null with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    (* Doctor returns JSON with status, checks, hints *)
+    let parsed = Yojson.Safe.from_string text in
+    let status = Yojson.Safe.Util.(parsed |> member "status" |> to_string) in
+    check bool "status is ok or needs_attention" true
+      (status = "ok" || status = "needs_attention");
+    let checks = Yojson.Safe.Util.(parsed |> member "checks" |> to_list) in
+    check bool "has checks" true (List.length checks > 0);
+    let hints = Yojson.Safe.Util.(parsed |> member "hints" |> to_list) in
+    check bool "has hints" true (List.length hints > 0)
+  | Error msg -> fail msg
+
+(* ============================================================
+   Group 4: handle_read_large_result — file I/O
+   ============================================================ *)
+
+let test_read_large_result_missing_path () =
+  match Mcp_tools.handle_read_large_result (`Assoc []) with
+  | Error msg ->
+    check bool "missing file_path" true
+      (try let _ = Str.search_forward (Str.regexp_string "file_path") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_read_large_result_outside_dir () =
+  match Mcp_tools.handle_read_large_result (`Assoc [("file_path", `String "/etc/passwd")]) with
+  | Error msg ->
+    check bool "must be under storage dir" true (String.length msg > 0)
+  | Ok _ -> fail "Expected error for path outside storage dir"
+
+let test_read_large_result_nonexistent () =
+  (* Create a path under the storage dir that doesn't exist *)
+  let storage_dir = Large_response.storage_dir in
+  let fake_path = Filename.concat storage_dir "nonexistent-file-12345.txt" in
+  match Mcp_tools.handle_read_large_result (`Assoc [("file_path", `String fake_path)]) with
+  | Error msg ->
+    check bool "file not found or path issue" true (String.length msg > 0)
+  | Ok _ -> fail "Expected error"
+
+let test_read_large_result_valid_file () =
+  (* Create a temporary file in the storage dir *)
+  let storage_dir = Large_response.storage_dir in
+  (try Unix.mkdir storage_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat storage_dir "test_tools_a5_tmp.txt" in
+  let content = "Hello, this is test content for read_large_result." in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  (match Mcp_tools.handle_read_large_result (`Assoc [("file_path", `String path)]) with
+   | Ok json ->
+     let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+     let parsed = Yojson.Safe.from_string text in
+     let chunk = Yojson.Safe.Util.(parsed |> member "chunk" |> to_string) in
+     check string "content matches" content chunk;
+     let eof = Yojson.Safe.Util.(parsed |> member "eof" |> to_bool) in
+     check bool "eof true for small file" true eof
+   | Error msg -> fail msg);
+  Sys.remove path
+
+let test_read_large_result_with_offset () =
+  let storage_dir = Large_response.storage_dir in
+  (try Unix.mkdir storage_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat storage_dir "test_tools_a5_offset.txt" in
+  let content = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  (match Mcp_tools.handle_read_large_result (`Assoc [
+    ("file_path", `String path);
+    ("offset", `Int 10);
+    ("limit", `Int 5);
+  ]) with
+   | Ok json ->
+     let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+     let parsed = Yojson.Safe.from_string text in
+     let chunk = Yojson.Safe.Util.(parsed |> member "chunk" |> to_string) in
+     check string "offset content" "KLMNO" chunk;
+     let read_bytes = Yojson.Safe.Util.(parsed |> member "read_bytes" |> to_int) in
+     check int "read 5 bytes" 5 read_bytes
+   | Error msg -> fail msg);
+  Sys.remove path
+
+let test_read_large_result_offset_beyond_eof () =
+  let storage_dir = Large_response.storage_dir in
+  (try Unix.mkdir storage_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat storage_dir "test_tools_a5_eof.txt" in
+  let oc = open_out path in
+  output_string oc "short";
+  close_out oc;
+  (match Mcp_tools.handle_read_large_result (`Assoc [
+    ("file_path", `String path);
+    ("offset", `Int 999);
+  ]) with
+   | Error msg ->
+     check bool "beyond eof" true
+       (try let _ = Str.search_forward (Str.regexp_string "beyond EOF") msg 0 in true with Not_found -> false)
+   | Ok _ -> fail "Expected error for offset beyond EOF");
+  Sys.remove path
+
+let test_read_large_result_negative_limit () =
+  let storage_dir = Large_response.storage_dir in
+  (try Unix.mkdir storage_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat storage_dir "test_tools_a5_neglim.txt" in
+  let oc = open_out path in
+  output_string oc "test data";
+  close_out oc;
+  (match Mcp_tools.handle_read_large_result (`Assoc [
+    ("file_path", `String path);
+    ("limit", `Int (-5));
+  ]) with
+   | Ok json ->
+     (* negative limit => defaults to 20000 *)
+     let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+     let parsed = Yojson.Safe.from_string text in
+     let limit_used = Yojson.Safe.Util.(parsed |> member "limit" |> to_int) in
+     check int "defaults to 20000" 20000 limit_used
+   | Error msg -> fail msg);
+  Sys.remove path
+
+(* ============================================================
+   Group 5: handle_codegen_sync — pure JSON processing
+   ============================================================ *)
+
+let test_codegen_sync_missing_json () =
+  match Mcp_tools.handle_codegen_sync (`Assoc []) with
+  | Error msg ->
+    check bool "missing json" true
+      (try let _ = Str.search_forward (Str.regexp_string "json") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_codegen_sync_invalid_json () =
+  match Mcp_tools.handle_codegen_sync (`Assoc [("json", `String "not-json{")]) with
+  | Error msg ->
+    check bool "parse error" true (String.length msg > 0)
+  | Ok _ -> fail "Expected error for invalid JSON"
+
+let test_codegen_sync_raw_format () =
+  let json_obj = `Assoc [("type", `String "FRAME"); ("name", `String "Test")] in
+  let args = `Assoc [
+    ("json", `String (Yojson.Safe.to_string json_obj));
+    ("format", `String "raw");
+  ] in
+  match Mcp_tools.handle_codegen_sync args with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    check bool "contains type" true
+      (try let _ = Str.search_forward (Str.regexp_string "FRAME") text 0 in true with Not_found -> false)
+  | Error msg -> fail msg
+
+let test_codegen_sync_fidelity_format () =
+  let json_obj = `Assoc [
+    ("type", `String "FRAME");
+    ("name", `String "Test");
+    ("children", `List []);
+  ] in
+  let args = `Assoc [
+    ("json", `String (Yojson.Safe.to_string json_obj));
+    ("format", `String "fidelity");
+  ] in
+  match Mcp_tools.handle_codegen_sync args with
+  | Ok _ -> () (* fidelity format produces some DSL output *)
+  | Error msg -> fail msg
+
+let test_codegen_sync_html_format () =
+  let json_obj = `Assoc [
+    ("type", `String "FRAME");
+    ("name", `String "HtmlTest");
+    ("children", `List []);
+  ] in
+  let args = `Assoc [
+    ("json", `String (Yojson.Safe.to_string json_obj));
+    ("format", `String "html");
+  ] in
+  match Mcp_tools.handle_codegen_sync args with
+  | Ok _ -> () (* html format produces output or fallback *)
+  | Error msg -> fail msg
+
+let test_codegen_sync_default_format () =
+  let json_obj = `Assoc [("type", `String "RECTANGLE"); ("name", `String "Rect")] in
+  let args = `Assoc [
+    ("json", `String (Yojson.Safe.to_string json_obj));
+  ] in
+  match Mcp_tools.handle_codegen_sync args with
+  | Ok _ -> () (* default format is fidelity *)
+  | Error msg -> fail msg
+
+(* ============================================================
+   Group 6: handle_category — dispatch logic
+   ============================================================ *)
+
+let test_category_list_core () =
+  match Mcp_tools.handle_category "core" (`Assoc [("mode", `String "list")]) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let cat = Yojson.Safe.Util.(parsed |> member "category" |> to_string) in
+    check string "category name" "core" cat;
+    let tools = Yojson.Safe.Util.(parsed |> member "tools" |> to_list) in
+    check bool "has tools" true (List.length tools > 0)
+  | Error msg -> fail msg
+
+let test_category_list_unknown () =
+  match Mcp_tools.handle_category "nonexistent_cat" (`Assoc [("mode", `String "list")]) with
+  | Error msg ->
+    check bool "unknown category" true
+      (try let _ = Str.search_forward (Str.regexp_string "Unknown category") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error for unknown category"
+
+let test_category_list_visual () =
+  match Mcp_tools.handle_category "visual" (`Assoc []) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let cat = Yojson.Safe.Util.(parsed |> member "category" |> to_string) in
+    check string "visual category" "visual" cat
+  | Error msg -> fail msg
+
+let test_category_describe_missing_tool () =
+  match Mcp_tools.handle_category "core" (`Assoc [("mode", `String "describe")]) with
+  | Error msg ->
+    check bool "missing tool" true
+      (try let _ = Str.search_forward (Str.regexp_string "tool") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_category_describe_tool_not_in_category () =
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("mode", `String "describe");
+    ("tool", `String "nonexistent_tool");
+  ]) with
+  | Error msg ->
+    check bool "tool not found" true
+      (try let _ = Str.search_forward (Str.regexp_string "not found") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_category_describe_valid_tool () =
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("mode", `String "describe");
+    ("tool", `String "get_file");
+  ]) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let name = Yojson.Safe.Util.(parsed |> member "name" |> to_string) in
+    check string "tool name" "get_file" name
+  | Error msg -> fail msg
+
+let test_category_call_missing_tool () =
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("mode", `String "call");
+  ]) with
+  | Error msg ->
+    check bool "missing tool" true
+      (try let _ = Str.search_forward (Str.regexp_string "tool") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_category_call_tool_not_found () =
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("mode", `String "call");
+    ("tool", `String "nonexistent_tool");
+    ("args", `Assoc []);
+  ]) with
+  | Error msg ->
+    check bool "not found" true
+      (try let _ = Str.search_forward (Str.regexp_string "not found") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_category_invalid_mode () =
+  (* Invalid mode raises Invalid_argument before the try/with block *)
+  let raised = ref false in
+  (try
+    let _ = Mcp_tools.handle_category "core" (`Assoc [
+      ("mode", `String "invalid_mode");
+    ]) in ()
+  with Invalid_argument msg ->
+    raised := true;
+    check bool "invalid mode msg" true
+      (try let _ = Str.search_forward (Str.regexp_string "Invalid mode") msg 0 in true with Not_found -> false));
+  check bool "raised Invalid_argument" true !raised
+
+let test_category_auto_list () =
+  (* No tool, no args => auto-list *)
+  match Mcp_tools.handle_category "team" (`Assoc []) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let cat = Yojson.Safe.Util.(parsed |> member "category" |> to_string) in
+    check string "auto-list team" "team" cat
+  | Error msg -> fail msg
+
+let test_category_auto_describe () =
+  (* tool present, no args => auto-describe *)
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("tool", `String "parse_url");
+  ]) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let name = Yojson.Safe.Util.(parsed |> member "name" |> to_string) in
+    check string "auto-describe parse_url" "parse_url" name
+  | Error msg -> fail msg
+
+let test_category_call_missing_args () =
+  (* tool present with args => call, but args is missing required fields *)
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("mode", `String "call");
+    ("tool", `String "parse_url");
+  ]) with
+  | Error msg ->
+    check bool "missing args" true
+      (try let _ = Str.search_forward (Str.regexp_string "args") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error for missing args"
+
+let test_category_list_components () =
+  match Mcp_tools.handle_category "components" (`Assoc [("mode", `String "list")]) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let cat = Yojson.Safe.Util.(parsed |> member "category" |> to_string) in
+    check string "components category" "components" cat
+  | Error msg -> fail msg
+
+let test_category_list_export () =
+  match Mcp_tools.handle_category "export" (`Assoc [("mode", `String "list")]) with
+  | Ok json ->
+    let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+    let parsed = Yojson.Safe.from_string text in
+    let cat = Yojson.Safe.Util.(parsed |> member "category" |> to_string) in
+    check string "export category" "export" cat
+  | Error msg -> fail msg
+
+(* ============================================================
+   Group 7: Effect-dependent handlers via run_with_mock
+   ============================================================ *)
+
+(* Save/restore FIGMA_TOKEN to avoid leaking state *)
+let with_figma_token token f =
+  let old = Sys.getenv_opt "FIGMA_TOKEN" in
+  Unix.putenv "FIGMA_TOKEN" token;
+  Fun.protect ~finally:(fun () ->
+    match old with
+    | Some v -> Unix.putenv "FIGMA_TOKEN" v
+    | None ->
+      (* Clear env var by setting empty; OCaml has no unsetenv *)
+      Unix.putenv "FIGMA_TOKEN" ""
+  ) f
+
+let test_get_me_ok () =
+  let store = Figma_effects.create_mock_store () in
+  store.me := Some (`Assoc [
+    ("id", `String "user-123");
+    ("email", `String "test@example.com");
+    ("handle", `String "testuser");
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_get_me (`Assoc []) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "contains user-123" true
+          (try let _ = Str.search_forward (Str.regexp_string "user-123") text 0 in true with Not_found -> false);
+        check bool "contains testuser" true
+          (try let _ = Str.search_forward (Str.regexp_string "testuser") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_get_me_no_token () =
+  let old = Sys.getenv_opt "FIGMA_TOKEN" in
+  Unix.putenv "FIGMA_TOKEN" "";
+  Fun.protect ~finally:(fun () ->
+    match old with
+    | Some v -> Unix.putenv "FIGMA_TOKEN" v
+    | None -> Unix.putenv "FIGMA_TOKEN" ""
+  ) (fun () ->
+    match Mcp_tools.handle_get_me (`Assoc []) with
+    | Error msg ->
+      check bool "missing token" true
+        (try let _ = Str.search_forward (Str.regexp_string "token") msg 0 in true with Not_found -> false)
+    | Ok _ -> fail "Expected error"
+  )
+
+let test_get_me_api_error () =
+  let store = Figma_effects.create_mock_store () in
+  (* me not set => Perform.get_me returns Error *)
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_get_me (`Assoc []) with
+      | Error _ -> ()
+      | Ok _ -> fail "Expected error when me not set"
+    ))
+
+let test_list_projects_ok () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.projects "team-42" (`Assoc [
+    ("projects", `List [
+      `Assoc [("id", `String "proj-1"); ("name", `String "Project Alpha")];
+      `Assoc [("id", `String "proj-2"); ("name", `String "Project Beta")];
+    ])
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_projects (`Assoc [("team_id", `String "team-42")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "found 2 projects" true
+          (try let _ = Str.search_forward (Str.regexp_string "2 projects") text 0 in true with Not_found -> false);
+        check bool "has Alpha" true
+          (try let _ = Str.search_forward (Str.regexp_string "Project Alpha") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_list_projects_missing_params () =
+  match Mcp_tools.handle_list_projects (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true
+      (try let _ = Str.search_forward (Str.regexp_string "Missing") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_list_projects_api_error () =
+  let store = Figma_effects.create_mock_store () in
+  (* No data seeded for team-99 => Error *)
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_projects (`Assoc [("team_id", `String "team-99")]) with
+      | Error _ -> ()
+      | Ok _ -> fail "Expected error for missing team"
+    ))
+
+let test_list_projects_empty_projects () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.projects "team-empty" (`Assoc [
+    ("projects", `List [])
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_projects (`Assoc [("team_id", `String "team-empty")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "found 0 projects" true
+          (try let _ = Str.search_forward (Str.regexp_string "0 projects") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_list_projects_no_projects_field () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.projects "team-noproj" (`Assoc [("other", `String "data")]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_projects (`Assoc [("team_id", `String "team-noproj")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "found 0" true
+          (try let _ = Str.search_forward (Str.regexp_string "0 projects") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_list_files_ok () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.project_files "proj-1" (`Assoc [
+    ("files", `List [
+      `Assoc [("key", `String "file-A"); ("name", `String "File Alpha")];
+      `Assoc [("key", `String "file-B"); ("name", `String "File Beta")];
+      `Assoc [("key", `String "file-C"); ("name", `String "File Gamma")];
+    ])
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_files (`Assoc [("project_id", `String "proj-1")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "found 3 files" true
+          (try let _ = Str.search_forward (Str.regexp_string "3 files") text 0 in true with Not_found -> false);
+        check bool "has File Alpha" true
+          (try let _ = Str.search_forward (Str.regexp_string "File Alpha") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_list_files_missing_params () =
+  match Mcp_tools.handle_list_files (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true
+      (try let _ = Str.search_forward (Str.regexp_string "Missing") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_list_files_api_error () =
+  let store = Figma_effects.create_mock_store () in
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_files (`Assoc [("project_id", `String "proj-missing")]) with
+      | Error _ -> ()
+      | Ok _ -> fail "Expected error"
+    ))
+
+let test_list_files_no_files_field () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.project_files "proj-nofiles" (`Assoc [("other", `String "data")]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_files (`Assoc [("project_id", `String "proj-nofiles")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "found 0 files" true
+          (try let _ = Str.search_forward (Str.regexp_string "0 files") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_list_files_partial_data () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.project_files "proj-partial" (`Assoc [
+    ("files", `List [
+      `Assoc [("key", `String "file-X")];  (* missing name *)
+      `Assoc [("name", `String "File Y")]; (* missing key *)
+      `Assoc [("key", `String "file-Z"); ("name", `String "File Z")]; (* complete *)
+    ])
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_list_files (`Assoc [("project_id", `String "proj-partial")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        (* Only file-Z has both key and name *)
+        check bool "found 1 file" true
+          (try let _ = Str.search_forward (Str.regexp_string "1 files") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+(* ============================================================
+   Group 8: Effect-dependent handlers — query, search, tree, stats, variables, tokens
+   ============================================================ *)
+
+let make_doc_json () =
+  `Assoc [
+    ("document", `Assoc [
+      ("id", `String "0:0");
+      ("name", `String "Document");
+      ("type", `String "DOCUMENT");
+      ("children", `List [
+        `Assoc [
+          ("id", `String "1:1");
+          ("name", `String "Page 1");
+          ("type", `String "CANVAS");
+          ("children", `List [
+            `Assoc [
+              ("id", `String "2:1");
+              ("name", `String "Frame A");
+              ("type", `String "FRAME");
+              ("absoluteBoundingBox", `Assoc [
+                ("x", `Float 0.0); ("y", `Float 0.0);
+                ("width", `Float 200.0); ("height", `Float 100.0);
+              ]);
+              ("children", `List []);
+            ];
+          ]);
+        ];
+      ]);
+    ]);
+  ]
+
+let test_handle_tree_ok () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.files "file-tree" (make_doc_json ());
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_tree (`Assoc [("file_key", `String "file-tree")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "has tree output" true (String.length text > 0)
+      | Error msg -> fail msg
+    ))
+
+let test_handle_tree_missing_params () =
+  match Mcp_tools.handle_tree (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true
+      (try let _ = Str.search_forward (Str.regexp_string "Missing") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_stats_ok () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.files "file-stats" (make_doc_json ());
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_stats (`Assoc [("file_key", `String "file-stats")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "has stats" true (String.length text > 0)
+      | Error msg -> fail msg
+    ))
+
+let test_handle_stats_missing_params () =
+  match Mcp_tools.handle_stats (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true (String.length msg > 0)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_get_variables_missing_params () =
+  match Mcp_tools.handle_get_variables (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true
+      (try let _ = Str.search_forward (Str.regexp_string "Missing") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_get_variables_ok () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.variables "file-vars" (`Assoc [
+    ("meta", `Assoc [
+      ("variableCollections", `Assoc [("coll-1", `Assoc [])]);
+      ("variables", `Assoc [
+        ("var-1", `Assoc [("name", `String "primary-color")]);
+        ("var-2", `Assoc [("name", `String "secondary-color")]);
+      ]);
+    ]);
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_get_variables (`Assoc [("file_key", `String "file-vars")]) with
+      | Ok json ->
+        let text = Yojson.Safe.Util.(json |> member "content" |> to_list |> List.hd |> member "text" |> to_string) in
+        check bool "has collections" true
+          (try let _ = Str.search_forward (Str.regexp_string "Collections: 1") text 0 in true with Not_found -> false);
+        check bool "has variables" true
+          (try let _ = Str.search_forward (Str.regexp_string "Variables: 2") text 0 in true with Not_found -> false)
+      | Error msg -> fail msg
+    ))
+
+let test_handle_get_variables_raw () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.variables "file-vars-raw" (`Assoc [("data", `String "test")]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_get_variables (`Assoc [
+        ("file_key", `String "file-vars-raw");
+        ("format", `String "raw");
+      ]) with
+      | Ok _ -> ()
+      | Error msg -> fail msg
+    ))
+
+let test_handle_get_variables_resolved () =
+  let store = Figma_effects.create_mock_store () in
+  Hashtbl.replace store.variables "file-vars-res" (`Assoc [
+    ("meta", `Assoc [
+      ("variableCollections", `Assoc []);
+      ("variables", `Assoc []);
+    ]);
+  ]);
+  with_figma_token "mock-token" (fun () ->
+    Figma_effects.run_with_mock store (fun () ->
+      match Mcp_tools.handle_get_variables (`Assoc [
+        ("file_key", `String "file-vars-res");
+        ("format", `String "resolved");
+      ]) with
+      | Ok _ -> ()
+      | Error msg -> fail msg
+    ))
+
+let test_handle_team_tree_missing_team_id () =
+  match Mcp_tools.handle_team_tree (`Assoc []) with
+  | Error msg ->
+    check bool "missing team_id" true
+      (try let _ = Str.search_forward (Str.regexp_string "team_id") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_team_tree_missing_token () =
+  let old = Sys.getenv_opt "FIGMA_TOKEN" in
+  Unix.putenv "FIGMA_TOKEN" "";
+  Fun.protect ~finally:(fun () ->
+    match old with
+    | Some v -> Unix.putenv "FIGMA_TOKEN" v
+    | None -> Unix.putenv "FIGMA_TOKEN" ""
+  ) (fun () ->
+    match Mcp_tools.handle_team_tree (`Assoc [("team_id", `String "t1")]) with
+    | Error msg ->
+      check bool "missing token" true
+        (try let _ = Str.search_forward (Str.regexp_string "token") msg 0 in true with Not_found -> false)
+    | Ok _ -> fail "Expected error"
+  )
+
+let test_handle_export_team_missing_params () =
+  match Mcp_tools.handle_export_team (`Assoc []) with
+  | Error msg ->
+    check bool "missing team_id" true
+      (try let _ = Str.search_forward (Str.regexp_string "team_id") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_export_team_missing_token () =
+  let old = Sys.getenv_opt "FIGMA_TOKEN" in
+  Unix.putenv "FIGMA_TOKEN" "";
+  Fun.protect ~finally:(fun () ->
+    match old with
+    | Some v -> Unix.putenv "FIGMA_TOKEN" v
+    | None -> Unix.putenv "FIGMA_TOKEN" ""
+  ) (fun () ->
+    match Mcp_tools.handle_export_team (`Assoc [("team_id", `String "t1")]) with
+    | Error msg ->
+      check bool "missing token" true
+        (try let _ = Str.search_forward (Str.regexp_string "token") msg 0 in true with Not_found -> false)
+    | Ok _ -> fail "Expected error"
+  )
+
+let test_handle_export_team_missing_output_dir () =
+  with_figma_token "mock-token" (fun () ->
+    match Mcp_tools.handle_export_team (`Assoc [("team_id", `String "t1")]) with
+    | Error msg ->
+      check bool "missing output_dir" true
+        (try let _ = Str.search_forward (Str.regexp_string "output_dir") msg 0 in true with Not_found -> false)
+    | Ok _ -> fail "Expected error"
+  )
+
+let test_handle_export_tokens_missing_params () =
+  match Mcp_tools.handle_export_tokens (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true (String.length msg > 0)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_query_missing_params () =
+  match Mcp_tools.handle_query (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true
+      (try let _ = Str.search_forward (Str.regexp_string "Missing") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+let test_handle_search_missing_params () =
+  match Mcp_tools.handle_search (`Assoc []) with
+  | Error msg ->
+    check bool "missing params" true
+      (try let _ = Str.search_forward (Str.regexp_string "Missing") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "Expected error"
+
+(* ============================================================
+   Group 9: is_under_dir and normalize_path helpers
+   ============================================================ *)
+
+let test_is_under_dir_true () =
+  (* Use /private/tmp on macOS where /tmp is a symlink to /private/tmp *)
+  let tmpdir = Filename.get_temp_dir_name () in
+  let test_file = Filename.concat tmpdir "test_is_under_dir_a5.txt" in
+  let oc = open_out test_file in close_out oc;
+  Fun.protect ~finally:(fun () -> Sys.remove test_file) (fun () ->
+    check bool "is under tmpdir" true (Mcp_tools.is_under_dir ~dir:tmpdir test_file))
+
+let test_is_under_dir_false () =
+  (* /usr/bin exists, /etc/passwd is not under it *)
+  check bool "not under /usr/bin" false (Mcp_tools.is_under_dir ~dir:"/usr/bin" "/etc/hosts")
+
+let test_is_under_dir_same () =
+  let tmpdir = Filename.get_temp_dir_name () in
+  check bool "same dir" true (Mcp_tools.is_under_dir ~dir:tmpdir tmpdir)
+
+let test_is_under_dir_nonexistent () =
+  check bool "nonexistent" false (Mcp_tools.is_under_dir ~dir:"/nonexistent123" "/nonexistent456/file")
+
+(* ============================================================
+   Group 10: is_network_error and string_contains helpers
+   ============================================================ *)
+
+let test_string_contains_found () =
+  check bool "found" true (Mcp_tools.string_contains "Hello World" "world")
+
+let test_string_contains_not_found () =
+  check bool "not found" false (Mcp_tools.string_contains "Hello World" "xyz")
+
+let test_string_contains_empty_sub () =
+  check bool "empty sub" true (Mcp_tools.string_contains "anything" "")
+
+let test_is_network_error_epipe () =
+  check bool "epipe" true
+    (Mcp_tools.is_network_error (Unix.Unix_error (Unix.EPIPE, "", "")))
+
+let test_is_network_error_econnreset () =
+  check bool "econnreset" true
+    (Mcp_tools.is_network_error (Unix.Unix_error (Unix.ECONNRESET, "", "")))
+
+let test_is_network_error_etimedout () =
+  check bool "etimedout" true
+    (Mcp_tools.is_network_error (Unix.Unix_error (Unix.ETIMEDOUT, "", "")))
+
+let test_is_network_error_other () =
+  check bool "not network" false
+    (Mcp_tools.is_network_error (Failure "some other error"))
+
+let test_is_network_error_string_match () =
+  check bool "broken pipe string" true
+    (Mcp_tools.is_network_error (Failure "broken pipe detected"))
+
+(* ============================================================
+   Test runner
+   ============================================================ *)
+
+let () =
+  run "Mcp_tools A5" [
+    ("handle_parse_url", [
+      test_case "design URL" `Quick test_parse_url_design_url;
+      test_case "file URL" `Quick test_parse_url_file_url;
+      test_case "team URL" `Quick test_parse_url_team_url;
+      test_case "proto URL" `Quick test_parse_url_proto_url;
+      test_case "invalid URL" `Quick test_parse_url_invalid_url;
+      test_case "missing url" `Quick test_parse_url_missing_url;
+      test_case "no node_id" `Quick test_parse_url_no_node_id;
+    ]);
+    ("handle_cache", [
+      test_case "stats" `Quick test_cache_stats;
+      test_case "invalidate all" `Quick test_cache_invalidate_all;
+      test_case "invalidate file_key" `Quick test_cache_invalidate_file_key;
+      test_case "invalidate file+node" `Quick test_cache_invalidate_file_and_node;
+    ]);
+    ("handle_doctor", [
+      test_case "system check" `Quick test_doctor;
+    ]);
+    ("handle_read_large_result", [
+      test_case "missing path" `Quick test_read_large_result_missing_path;
+      test_case "outside dir" `Quick test_read_large_result_outside_dir;
+      test_case "nonexistent" `Quick test_read_large_result_nonexistent;
+      test_case "valid file" `Quick test_read_large_result_valid_file;
+      test_case "with offset" `Quick test_read_large_result_with_offset;
+      test_case "offset beyond EOF" `Quick test_read_large_result_offset_beyond_eof;
+      test_case "negative limit" `Quick test_read_large_result_negative_limit;
+    ]);
+    ("handle_codegen_sync", [
+      test_case "missing json" `Quick test_codegen_sync_missing_json;
+      test_case "invalid json" `Quick test_codegen_sync_invalid_json;
+      test_case "raw format" `Quick test_codegen_sync_raw_format;
+      test_case "fidelity format" `Quick test_codegen_sync_fidelity_format;
+      test_case "html format" `Quick test_codegen_sync_html_format;
+      test_case "default format" `Quick test_codegen_sync_default_format;
+    ]);
+    ("handle_category", [
+      test_case "list core" `Quick test_category_list_core;
+      test_case "list unknown" `Quick test_category_list_unknown;
+      test_case "list visual" `Quick test_category_list_visual;
+      test_case "describe missing tool" `Quick test_category_describe_missing_tool;
+      test_case "describe not in category" `Quick test_category_describe_tool_not_in_category;
+      test_case "describe valid" `Quick test_category_describe_valid_tool;
+      test_case "call missing tool" `Quick test_category_call_missing_tool;
+      test_case "call not found" `Quick test_category_call_tool_not_found;
+      test_case "invalid mode" `Quick test_category_invalid_mode;
+      test_case "auto-list" `Quick test_category_auto_list;
+      test_case "auto-describe" `Quick test_category_auto_describe;
+      test_case "call missing args" `Quick test_category_call_missing_args;
+      test_case "list components" `Quick test_category_list_components;
+      test_case "list export" `Quick test_category_list_export;
+    ]);
+    ("handle_get_me", [
+      test_case "ok" `Quick test_get_me_ok;
+      test_case "no token" `Quick test_get_me_no_token;
+      test_case "api error" `Quick test_get_me_api_error;
+    ]);
+    ("handle_list_projects", [
+      test_case "ok" `Quick test_list_projects_ok;
+      test_case "missing params" `Quick test_list_projects_missing_params;
+      test_case "api error" `Quick test_list_projects_api_error;
+      test_case "empty projects" `Quick test_list_projects_empty_projects;
+      test_case "no projects field" `Quick test_list_projects_no_projects_field;
+    ]);
+    ("handle_list_files", [
+      test_case "ok" `Quick test_list_files_ok;
+      test_case "missing params" `Quick test_list_files_missing_params;
+      test_case "api error" `Quick test_list_files_api_error;
+      test_case "no files field" `Quick test_list_files_no_files_field;
+      test_case "partial data" `Quick test_list_files_partial_data;
+    ]);
+    ("handle_tree", [
+      test_case "ok" `Quick test_handle_tree_ok;
+      test_case "missing params" `Quick test_handle_tree_missing_params;
+    ]);
+    ("handle_stats", [
+      test_case "ok" `Quick test_handle_stats_ok;
+      test_case "missing params" `Quick test_handle_stats_missing_params;
+    ]);
+    ("handle_get_variables", [
+      test_case "missing params" `Quick test_handle_get_variables_missing_params;
+      test_case "summary format" `Quick test_handle_get_variables_ok;
+      test_case "raw format" `Quick test_handle_get_variables_raw;
+      test_case "resolved format" `Quick test_handle_get_variables_resolved;
+    ]);
+    ("handle_team_tree", [
+      test_case "missing team_id" `Quick test_handle_team_tree_missing_team_id;
+      test_case "missing token" `Quick test_handle_team_tree_missing_token;
+    ]);
+    ("handle_export_team", [
+      test_case "missing params" `Quick test_handle_export_team_missing_params;
+      test_case "missing token" `Quick test_handle_export_team_missing_token;
+      test_case "missing output_dir" `Quick test_handle_export_team_missing_output_dir;
+    ]);
+    ("handle_export_tokens", [
+      test_case "missing params" `Quick test_handle_export_tokens_missing_params;
+    ]);
+    ("handle_query", [
+      test_case "missing params" `Quick test_handle_query_missing_params;
+    ]);
+    ("handle_search", [
+      test_case "missing params" `Quick test_handle_search_missing_params;
+    ]);
+    ("is_under_dir", [
+      test_case "true" `Quick test_is_under_dir_true;
+      test_case "false" `Quick test_is_under_dir_false;
+      test_case "same" `Quick test_is_under_dir_same;
+      test_case "nonexistent" `Quick test_is_under_dir_nonexistent;
+    ]);
+    ("string_contains / is_network_error", [
+      test_case "contains found" `Quick test_string_contains_found;
+      test_case "contains not found" `Quick test_string_contains_not_found;
+      test_case "contains empty" `Quick test_string_contains_empty_sub;
+      test_case "epipe" `Quick test_is_network_error_epipe;
+      test_case "econnreset" `Quick test_is_network_error_econnreset;
+      test_case "etimedout" `Quick test_is_network_error_etimedout;
+      test_case "other" `Quick test_is_network_error_other;
+      test_case "string match" `Quick test_is_network_error_string_match;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

Phase A5 coverage push: 261 new tests across 5 files, improving overall project coverage from 87.54% to 87.96%.

## Test Files

| File | Tests | Target Module(s) |
|------|-------|-------------------|
| `test_server_metrics_a5.ml` | 19 | `server_metrics.ml` |
| `test_protocol_a5.ml` | 49 | `mcp_protocol_eio.ml` |
| `test_similarity_a5.ml` | 83 | `figma_similarity.ml` |
| `test_tools_a5.ml` | 80 | `mcp_tools.ml` |
| `test_html_metrics_a5.ml` | 30 | `html_metrics.ml` |

## Per-file Coverage Changes (key files)

| File | Coverage | Points |
|------|----------|--------|
| `mcp_tools.ml` | 86.00% | 1554/1807 |
| `figma_similarity.ml` | 96.68% | 233/241 |
| `html_metrics.ml` | 88.44% | 199/225 |
| `server_metrics.ml` | 76.39% | 110/144 |
| `mcp_protocol_eio.ml` | 40.00% | 44/110 |

**Overall**: 87.54% → **87.96%** (+0.42pp, 10857/12343 points)

## Test plan
- [x] `dune runtest` — all 261 new tests pass
- [x] bisect-ppx-report confirms coverage above 87% threshold
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)