### PR TITLE
fix: log file fetch failures in figma_crawl

### DIFF
--- a/lib/figma_crawl.ml
+++ b/lib/figma_crawl.ml
@@ -529,7 +529,8 @@ let team_tree ~token ~team_id
                      (* 상세 노드 트리 렌더링 *)
                      if node_depth > 0 then
                        render_node_tree ~indent:5 ~max_depth:node_depth ~depth:0 document buf
-                 | Error _ -> ()
+                 | Error err ->
+                  progress.errors <- (Printf.sprintf "File fetch failed: %s" err) :: progress.errors
                end
              ) files
          | Error err ->


### PR DESCRIPTION
## Summary
- `figma_crawl.ml` L532: `| Error _ -> ()` → `progress.errors` 누적으로 변경
- 기존 `progress.errors` 패턴 재사용 (파일 내 8곳에서 동일 패턴 사용 중)

## Change
```ocaml
(* Before *)
| Error _ -> ()

(* After *)
| Error err ->
  progress.errors <- (Printf.sprintf "File fetch failed: %s" err) :: progress.errors
```

## Impact
- 제어 흐름 변경 없음
- fetch 실패 시 `progress.errors`에 누적되어 최종 리포트에 포함됨
- `dune build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)