### PR TITLE
refactor: unify string_contains, remove dead code, fix unsafe_to_string

### DIFF
--- a/lib/figma_api_eio.ml
+++ b/lib/figma_api_eio.ml
@@ -6,15 +6,16 @@
 
 open Printf
 
-let string_contains s sub =
-  let len_s = String.length s in
-  let len_sub = String.length sub in
-  let rec loop i =
-    if i + len_sub > len_s then false
-    else if String.sub s i len_sub = sub then true
-    else loop (i + 1)
-  in
-  if len_sub = 0 then true else loop 0
+(** Case-insensitive substring check (local — cannot depend on Mcp_helpers due to cycle) *)
+let string_contains_ci ~haystack ~needle =
+  let needle = String.lowercase_ascii (String.trim needle) in
+  if needle = "" then false
+  else
+    let haystack = String.lowercase_ascii haystack in
+    try
+      ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
+      true
+    with Not_found -> false
 
 (** ============== Types ============== *)
 
@@ -40,7 +41,7 @@ type error_recovery = {
 
 (** Body 기반 에러 키워드 감지 *)
 let body_contains body keyword =
-  string_contains (String.lowercase_ascii body) keyword
+  string_contains_ci ~haystack:body ~needle:keyword
 
 let body_contains_any body keywords =
   List.exists (body_contains body) keywords
@@ -198,12 +199,13 @@ let max_body_size = Figma_config.Http.max_body_bytes
 let log_response_body = Figma_config.Http.log_response_body
 
 let is_dns_failure exn =
-  let msg = Printexc.to_string exn |> String.lowercase_ascii in
-  string_contains msg "resolve" || string_contains msg "dns"
+  let msg = Printexc.to_string exn in
+  string_contains_ci ~haystack:msg ~needle:"resolve" ||
+  string_contains_ci ~haystack:msg ~needle:"dns"
 
 let is_html_response body =
   let trimmed = String.trim body in
-  string_contains (String.lowercase_ascii trimmed) "<html"
+  string_contains_ci ~haystack:trimmed ~needle:"<html"
 
 let retry_after_of_headers headers =
   match Cohttp.Header.get headers "retry-after" with
@@ -514,12 +516,12 @@ let read_http_response_from_flow br =
   let headers = read_headers br in
   let connection_close =
     match header_value headers "connection" with
-    | Some value -> string_contains (String.lowercase_ascii value) "close"
+    | Some value -> string_contains_ci ~haystack:value ~needle:"close"
     | None -> false
   in
   let is_chunked =
     match header_value headers "transfer-encoding" with
-    | Some value -> string_contains (String.lowercase_ascii value) "chunked"
+    | Some value -> string_contains_ci ~haystack:value ~needle:"chunked"
     | None -> false
   in
   let content_length =

--- a/lib/mcp_agent_queue.ml
+++ b/lib/mcp_agent_queue.ml
@@ -67,7 +67,7 @@ let hex_of_bytes (b : bytes) =
     Bytes.set out (i * 2) hex.[v lsr 4];
     Bytes.set out (i * 2 + 1) hex.[v land 0x0f];
   done;
-  Bytes.unsafe_to_string out
+  Bytes.to_string out
 
 let random_bytes len =
   let fd = Unix.openfile "/dev/urandom" [Unix.O_RDONLY] 0 in

--- a/lib/mcp_api_handlers.ml
+++ b/lib/mcp_api_handlers.ml
@@ -37,21 +37,9 @@ let normalize_patterns patterns =
   |> List.map String.trim
   |> List.filter (fun p -> p <> "")
 
-let string_contains ~needle ~haystack =
-  let needle = String.lowercase_ascii (String.trim needle) in
-  if needle = "" then false
-  else
-    let haystack = String.lowercase_ascii haystack in
-    try
-      ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
-      true
-    with Not_found -> false
-
-let matches_any patterns text =
-  List.exists (fun p -> string_contains ~needle:p ~haystack:text) patterns
-
-let find_matching_pattern patterns text =
-  List.find_opt (fun p -> string_contains ~needle:p ~haystack:text) patterns
+let string_contains = Mcp_helpers.string_contains
+let matches_any = Mcp_helpers.matches_any
+let find_matching_pattern = Mcp_helpers.find_matching_pattern
 
 let node_text_blob node =
   match node.Figma_types.characters with

--- a/lib/mcp_api_handlers.mli
+++ b/lib/mcp_api_handlers.mli
@@ -22,7 +22,7 @@ type selection_config = {
 val default_exclude_patterns : string list
 val default_note_patterns : string list
 val normalize_patterns : string list -> string list
-val string_contains : needle:string -> haystack:string -> bool
+val string_contains : haystack:string -> needle:string -> bool
 val matches_any : string list -> string -> bool
 val find_matching_pattern : string list -> string -> string option
 val node_text_blob : Figma_types.ui_node -> string

--- a/lib/mcp_helpers.ml
+++ b/lib/mcp_helpers.ml
@@ -1,5 +1,23 @@
 (** Figma MCP shared helpers — JSON, Schema, Cache, Error, Parameter extraction *)
 
+(** ============== String search ============== *)
+
+let string_contains ~haystack ~needle =
+  let needle = String.lowercase_ascii (String.trim needle) in
+  if needle = "" then false
+  else
+    let haystack = String.lowercase_ascii haystack in
+    try
+      ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
+      true
+    with Not_found -> false
+
+let matches_any patterns text =
+  List.exists (fun p -> string_contains ~needle:p ~haystack:text) patterns
+
+let find_matching_pattern patterns text =
+  List.find_opt (fun p -> string_contains ~needle:p ~haystack:text) patterns
+
 (** ============== JSON → DSL 변환 (Figma_mcp 순환 의존 방지) ============== *)
 let process_json_string ~format json_str =
   try

--- a/lib/mcp_helpers.mli
+++ b/lib/mcp_helpers.mli
@@ -2,6 +2,17 @@
 
     Foundation module used by all other mcp_* modules. *)
 
+(** {1 String search} *)
+
+(** Case-insensitive substring check. Trims and lowercases needle. *)
+val string_contains : haystack:string -> needle:string -> bool
+
+(** [matches_any patterns text] returns true if any pattern matches [text]. *)
+val matches_any : string list -> string -> bool
+
+(** [find_matching_pattern patterns text] returns the first matching pattern. *)
+val find_matching_pattern : string list -> string -> string option
+
 (** {1 JSON → DSL conversion} *)
 
 val process_json_string : format:string -> string -> (string, string) result

--- a/lib/mcp_tools.ml
+++ b/lib/mcp_tools.ml
@@ -1,34 +1,17 @@
-let string_contains s sub = 
-  let len_s = String.length s in 
-  let len_sub = String.length sub in 
-  if len_sub = 0 then true 
-  else if len_sub > len_s then false 
-  else 
-    let found = ref false in 
-    for i = 0 to len_s - len_sub do 
-      if not !found then 
-        let match_at_i = ref true in 
-        for j = 0 to len_sub - 1 do 
-          if Char.lowercase_ascii s.[i + j] <> Char.lowercase_ascii sub.[j] then 
-            match_at_i := false 
-        done; 
-        if !match_at_i then found := true 
-    done; 
-    !found 
-
-let is_network_error exn = 
-  match exn with 
-  | Unix.Unix_error (Unix.EPIPE, _, _) 
-  | Unix.Unix_error (Unix.ECONNRESET, _, _) 
-  | Unix.Unix_error (Unix.ETIMEDOUT, _, _) -> true 
-  | _ -> 
-      let s = Printexc.to_string exn in 
-      string_contains s "broken pipe" || 
-      string_contains s "connection reset" || 
-      string_contains s "connection timed out" || 
-      string_contains s "econnreset" || 
-      string_contains s "epipe" || 
-      string_contains s "etimedout" 
+let is_network_error exn =
+  let sc = Mcp_helpers.string_contains in
+  match exn with
+  | Unix.Unix_error (Unix.EPIPE, _, _)
+  | Unix.Unix_error (Unix.ECONNRESET, _, _)
+  | Unix.Unix_error (Unix.ETIMEDOUT, _, _) -> true
+  | _ ->
+      let s = Printexc.to_string exn in
+      sc ~haystack:s ~needle:"broken pipe" ||
+      sc ~haystack:s ~needle:"connection reset" ||
+      sc ~haystack:s ~needle:"connection timed out" ||
+      sc ~haystack:s ~needle:"econnreset" ||
+      sc ~haystack:s ~needle:"epipe" ||
+      sc ~haystack:s ~needle:"etimedout"
 
 (** Figma MCP Tools 정의 *)
 
@@ -284,42 +267,6 @@ let tool_figma_verify_semantic : tool_def = {
     ("text_color_tol_rgb", number_prop "텍스트 색상 RGB 거리 허용치(0-1, 기본값: 0.15)");
     ("version", string_prop "특정 파일 버전 ID");
   ] ["file_key"; "node_id"; "html"];
-}
-
-(** Region-based comparison - 영역별 상세 비교 *)
-let tool_figma_compare_regions : tool_def = {
-  name = "figma_compare_regions";
-  description = "[DEPRECATED] figma_compare(mode: \"regions\")를 사용하세요. 영역별 이미지 비교 기능은 통합 compare 도구로 이전되었습니다.";
-  input_schema = object_schema [
-    ("image_a", string_prop "기준 이미지 경로 (Figma 렌더)");
-    ("image_b", string_prop "비교 이미지 경로 (HTML 렌더)");
-    ("regions", string_prop "비교할 영역 JSON 배열 [{name, x, y, width, height}]");
-    ("output_dir", string_prop "결과 저장 디렉토리 (기본값: /tmp/figma-evolution/regions)");
-    ("generate_diff", bool_prop "차이 이미지 생성 여부 (기본값: true)");
-  ] ["image_a"; "image_b"; "regions"];
-}
-
-(** Evolution Report - 진화 과정 리포트 조회 *)
-let tool_figma_evolution_report : tool_def = {
-  name = "figma_evolution_report";
-  description = "[DEPRECATED] figma_compare(mode: \"evolution\")를 사용하세요. 진화 리포트 기능은 통합 compare 도구로 이전되었습니다.";
-  input_schema = object_schema [
-    ("run_dir", string_prop "Evolution 디렉토리 경로 (예: /tmp/figma-evolution/run_1234567890). 없으면 최근 실행 목록 반환");
-    ("generate_image", bool_prop "비교 이미지 자동 생성 여부 (기본값: true)");
-  ] [];
-}
-
-(** Compare Elements - 색상/박스 확장 메트릭 비교 *)
-let tool_figma_compare_elements : tool_def = {
-  name = "figma_compare_elements";
-  description = "[DEPRECATED] figma_compare(mode: \"elements\")를 사용하세요. 색상/박스 비교 기능은 통합 compare 도구로 이전되었습니다.";
-  input_schema = object_schema [
-    ("type", enum_prop ["color"; "box"; "full"] "비교 타입: color(색상), box(박스), full(둘 다)");
-    ("color1", string_prop "첫 번째 색상 (#RRGGBB 또는 rgb(r,g,b))");
-    ("color2", string_prop "두 번째 색상 (#RRGGBB 또는 rgb(r,g,b))");
-    ("box1", string_prop "첫 번째 박스 (x,y,w,h 형식)");
-    ("box2", string_prop "두 번째 박스 (x,y,w,h 형식)");
-  ] ["type"];
 }
 
 let tool_figma_export_image : tool_def = {
@@ -1018,7 +965,6 @@ let tool_categories = [
              "tree"; "get_file_versions"; "parse_url"; "get_me"; "query"; "search"] };
   { name = "visual";
     description = "시각 검증 (SSIM, 비교)";
-    (* NOTE: compare_elements, compare_regions, evolution_report는 DEPRECATED → figma_compare(mode=...)로 통합 *)
     tools = ["verify_semantic"; "verify_visual"; "image_similarity"; "compare"; "fidelity_loop"] };
   (* plugin: monolithic tool로 직접 노출 (sub-handlers 미등록으로 category 라우팅 불가) *)
   { name = "team";

--- a/test/test_api_effects_w5.ml
+++ b/test/test_api_effects_w5.ml
@@ -14,25 +14,25 @@ open Alcotest
 
 let test_string_contains_basic () =
   check bool "substring found" true
-    (Figma_api_eio.string_contains "hello world" "world");
+    (Figma_api_eio.string_contains_ci ~haystack:"hello world" ~needle:"world");
   check bool "substring not found" false
-    (Figma_api_eio.string_contains "hello world" "xyz")
+    (Figma_api_eio.string_contains_ci ~haystack:"hello world" ~needle:"xyz")
 
 let test_string_contains_empty_sub () =
-  check bool "empty substring always matches" true
-    (Figma_api_eio.string_contains "anything" "")
+  check bool "empty substring returns false" false
+    (Figma_api_eio.string_contains_ci ~haystack:"anything" ~needle:"")
 
 let test_string_contains_empty_string () =
   check bool "empty string, non-empty sub" false
-    (Figma_api_eio.string_contains "" "abc")
+    (Figma_api_eio.string_contains_ci ~haystack:"" ~needle:"abc")
 
 let test_string_contains_equal () =
   check bool "exact match" true
-    (Figma_api_eio.string_contains "abc" "abc")
+    (Figma_api_eio.string_contains_ci ~haystack:"abc" ~needle:"abc")
 
 let test_string_contains_longer_sub () =
   check bool "sub longer than string" false
-    (Figma_api_eio.string_contains "ab" "abcd")
+    (Figma_api_eio.string_contains_ci ~haystack:"ab" ~needle:"abcd")
 
 (* ============== figma_api_eio: body_contains / body_contains_any ============== *)
 
@@ -80,61 +80,61 @@ let test_first_match_no_hit () =
 let test_suggestion_400_invalid_id () =
   let s = Figma_api_eio.suggestion_for_400 "Invalid ID format in request" in
   check bool "mentions ID" true
-    (Figma_api_eio.string_contains s "Invalid ID")
+    (Figma_api_eio.string_contains_ci ~haystack:s ~needle:"Invalid ID")
 
 let test_suggestion_400_missing () =
   let s = Figma_api_eio.suggestion_for_400 "Missing required parameter" in
   check bool "mentions missing" true
-    (Figma_api_eio.string_contains s "Missing")
+    (Figma_api_eio.string_contains_ci ~haystack:s ~needle:"Missing")
 
 let test_suggestion_400_node () =
   let s = Figma_api_eio.suggestion_for_400 "Node error occurred" in
   check bool "mentions node" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "node")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"node")
 
 let test_suggestion_400_default () =
   let s = Figma_api_eio.suggestion_for_400 "some other error" in
   check bool "default suggestion" true
-    (Figma_api_eio.string_contains s "Invalid request")
+    (Figma_api_eio.string_contains_ci ~haystack:s ~needle:"Invalid request")
 
 (* ============== figma_api_eio: suggestion_for_404 ============== *)
 
 let test_suggestion_404_file () =
   let s = Figma_api_eio.suggestion_for_404 "File not found" in
   check bool "mentions file" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "file")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"file")
 
 let test_suggestion_404_node () =
   let s = Figma_api_eio.suggestion_for_404 "Node not found" in
   check bool "mentions node" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "node")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"node")
 
 let test_suggestion_404_version () =
   let s = Figma_api_eio.suggestion_for_404 "Version not found" in
   check bool "mentions version" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "version")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"version")
 
 let test_suggestion_404_default () =
   let s = Figma_api_eio.suggestion_for_404 "generic 404" in
   check bool "default suggestion" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "not found")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"not found")
 
 (* ============== figma_api_eio: suggestion_for_403 ============== *)
 
 let test_suggestion_403_scope () =
   let s = Figma_api_eio.suggestion_for_403 "file_variables:read scope required" in
   check bool "mentions scope" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "scope")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"scope")
 
 let test_suggestion_403_invalid_scope () =
   let s = Figma_api_eio.suggestion_for_403 "invalid scope for this token" in
   check bool "mentions scope" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "scope")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"scope")
 
 let test_suggestion_403_generic () =
   let s = Figma_api_eio.suggestion_for_403 "access denied" in
   check bool "mentions permission" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "permission")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"permission")
 
 (* ============== figma_api_eio: truncate_body ============== *)
 
@@ -219,19 +219,19 @@ let test_friendly_string_network () =
   let err = Figma_api_eio.Network_error "DNS resolution failed" in
   let s = Figma_api_eio.api_error_to_friendly_string err in
   check bool "contains dns" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "dns")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"dns")
 
 let test_friendly_string_json () =
   let err = Figma_api_eio.Json_error "unexpected token at position 0" in
   let s = Figma_api_eio.api_error_to_friendly_string err in
   check bool "contains invalid" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "invalid")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"invalid")
 
 let test_friendly_string_timeout () =
   let err = Figma_api_eio.Timeout_error in
   let s = Figma_api_eio.api_error_to_friendly_string err in
   check bool "contains timed out" true
-    (Figma_api_eio.string_contains (String.lowercase_ascii s) "timed out")
+    (Figma_api_eio.string_contains_ci ~haystack:(String.lowercase_ascii s) ~needle:"timed out")
 
 (* ============== figma_api_eio: get_retry_delay Network_error ============== *)
 
@@ -338,7 +338,7 @@ let test_parse_neo4j_code_only_error () =
   match result with
   | Error msg ->
       check bool "has error code" true
-        (Figma_api_eio.string_contains msg "Neo.Error")
+        (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"Neo.Error")
   | Ok _ -> fail "expected error"
 
 let test_parse_neo4j_message_only_error () =
@@ -347,7 +347,7 @@ let test_parse_neo4j_message_only_error () =
   match result with
   | Error msg ->
       check bool "has error message" true
-        (Figma_api_eio.string_contains msg "something wrong")
+        (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"something wrong")
   | Ok _ -> fail "expected error"
 
 let test_parse_neo4j_multiple_errors () =
@@ -358,8 +358,8 @@ let test_parse_neo4j_multiple_errors () =
   let result = Figma_effects.parse_neo4j_response body in
   match result with
   | Error msg ->
-      check bool "has first" true (Figma_api_eio.string_contains msg "Error1");
-      check bool "has second" true (Figma_api_eio.string_contains msg "Error2")
+      check bool "has first" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"Error1");
+      check bool "has second" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"Error2")
   | Ok _ -> fail "expected error"
 
 let test_parse_neo4j_missing_code_key () =
@@ -368,7 +368,7 @@ let test_parse_neo4j_missing_code_key () =
   let result = Figma_effects.parse_neo4j_response body in
   match result with
   | Error msg ->
-      check bool "has message" true (Figma_api_eio.string_contains msg "oops")
+      check bool "has message" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"oops")
   | Ok _ -> fail "expected error"
 
 (* ============== figma_effects: make_neo4j_statement edge cases ============== *)

--- a/test/test_api_eio_w11.ml
+++ b/test/test_api_eio_w11.ml
@@ -21,29 +21,29 @@ open Figma_api_eio
 (* ---- string_contains ---- *)
 
 let test_string_contains_basic () =
-  Alcotest.(check bool) "substring present" true (string_contains "hello world" "world");
-  Alcotest.(check bool) "substring absent" false (string_contains "hello world" "xyz")
+  Alcotest.(check bool) "substring present" true (string_contains_ci ~haystack:"hello world" ~needle:"world");
+  Alcotest.(check bool) "substring absent" false (string_contains_ci ~haystack:"hello world" ~needle:"xyz")
 
 let test_string_contains_empty_sub () =
-  Alcotest.(check bool) "empty sub always matches" true (string_contains "anything" "")
+  Alcotest.(check bool) "empty sub returns false" false (string_contains_ci ~haystack:"anything" ~needle:"")
 
 let test_string_contains_empty_haystack () =
-  Alcotest.(check bool) "empty haystack, non-empty sub" false (string_contains "" "a")
+  Alcotest.(check bool) "empty haystack, non-empty sub" false (string_contains_ci ~haystack:"" ~needle:"a")
 
 let test_string_contains_both_empty () =
-  Alcotest.(check bool) "both empty" true (string_contains "" "")
+  Alcotest.(check bool) "both empty" false (string_contains_ci ~haystack:"" ~needle:"")
 
 let test_string_contains_equal () =
-  Alcotest.(check bool) "exact match" true (string_contains "abc" "abc")
+  Alcotest.(check bool) "exact match" true (string_contains_ci ~haystack:"abc" ~needle:"abc")
 
 let test_string_contains_longer_sub () =
-  Alcotest.(check bool) "sub longer than haystack" false (string_contains "ab" "abc")
+  Alcotest.(check bool) "sub longer than haystack" false (string_contains_ci ~haystack:"ab" ~needle:"abc")
 
 let test_string_contains_at_end () =
-  Alcotest.(check bool) "match at end" true (string_contains "foobar" "bar")
+  Alcotest.(check bool) "match at end" true (string_contains_ci ~haystack:"foobar" ~needle:"bar")
 
 let test_string_contains_at_start () =
-  Alcotest.(check bool) "match at start" true (string_contains "foobar" "foo")
+  Alcotest.(check bool) "match at start" true (string_contains_ci ~haystack:"foobar" ~needle:"foo")
 
 (* ---- body_contains / body_contains_any ---- *)
 
@@ -104,19 +104,19 @@ let test_first_match_empty_rules () =
 let test_http_400_invalid_id () =
   let r = get_http_error_recovery 400 "invalid id format" None in
   Alcotest.(check bool) "not retryable" false r.retryable;
-  Alcotest.(check bool) "mentions invalid ID" true (string_contains r.suggestion "Invalid ID")
+  Alcotest.(check bool) "mentions invalid ID" true (string_contains_ci ~haystack:r.suggestion ~needle:"Invalid ID")
 
 let test_http_400_missing () =
   let r = get_http_error_recovery 400 "missing parameter" None in
-  Alcotest.(check bool) "mentions missing" true (string_contains r.suggestion "Missing")
+  Alcotest.(check bool) "mentions missing" true (string_contains_ci ~haystack:r.suggestion ~needle:"Missing")
 
 let test_http_400_node () =
   let r = get_http_error_recovery 400 "node error" None in
-  Alcotest.(check bool) "mentions node" true (string_contains r.suggestion "Node")
+  Alcotest.(check bool) "mentions node" true (string_contains_ci ~haystack:r.suggestion ~needle:"Node")
 
 let test_http_400_generic () =
   let r = get_http_error_recovery 400 "something else" None in
-  Alcotest.(check bool) "generic 400" true (string_contains r.suggestion "Invalid request")
+  Alcotest.(check bool) "generic 400" true (string_contains_ci ~haystack:r.suggestion ~needle:"Invalid request")
 
 let test_http_401 () =
   let r = get_http_error_recovery 401 "" None in
@@ -125,31 +125,31 @@ let test_http_401 () =
 
 let test_http_403_scope () =
   let r = get_http_error_recovery 403 "file_variables:read scope required" None in
-  Alcotest.(check bool) "mentions scope" true (string_contains r.suggestion "file_variables:read")
+  Alcotest.(check bool) "mentions scope" true (string_contains_ci ~haystack:r.suggestion ~needle:"file_variables:read")
 
 let test_http_403_invalid_scope () =
   let r = get_http_error_recovery 403 "invalid scope detected" None in
-  Alcotest.(check bool) "mentions scope" true (string_contains r.suggestion "file_variables:read")
+  Alcotest.(check bool) "mentions scope" true (string_contains_ci ~haystack:r.suggestion ~needle:"file_variables:read")
 
 let test_http_403_generic () =
   let r = get_http_error_recovery 403 "no access" None in
-  Alcotest.(check bool) "mentions permission" true (string_contains r.suggestion "permission")
+  Alcotest.(check bool) "mentions permission" true (string_contains_ci ~haystack:r.suggestion ~needle:"permission")
 
 let test_http_404_file () =
   let r = get_http_error_recovery 404 "file not accessible" None in
-  Alcotest.(check bool) "mentions file" true (string_contains r.suggestion "File not found")
+  Alcotest.(check bool) "mentions file" true (string_contains_ci ~haystack:r.suggestion ~needle:"File not found")
 
 let test_http_404_node () =
   let r = get_http_error_recovery 404 "node not found" None in
-  Alcotest.(check bool) "mentions node" true (string_contains r.suggestion "Node not found")
+  Alcotest.(check bool) "mentions node" true (string_contains_ci ~haystack:r.suggestion ~needle:"Node not found")
 
 let test_http_404_version () =
   let r = get_http_error_recovery 404 "version not found" None in
-  Alcotest.(check bool) "mentions version" true (string_contains r.suggestion "Version not found")
+  Alcotest.(check bool) "mentions version" true (string_contains_ci ~haystack:r.suggestion ~needle:"Version not found")
 
 let test_http_404_generic () =
   let r = get_http_error_recovery 404 "who knows" None in
-  Alcotest.(check bool) "generic 404" true (string_contains r.suggestion "Resource not found")
+  Alcotest.(check bool) "generic 404" true (string_contains_ci ~haystack:r.suggestion ~needle:"Resource not found")
 
 let test_http_429_with_header () =
   let r = get_http_error_recovery 429 "" (Some 30.0) in
@@ -204,7 +204,7 @@ let test_http_504 () =
 let test_http_unknown () =
   let r = get_http_error_recovery 418 "" None in
   Alcotest.(check bool) "not retryable" false r.retryable;
-  Alcotest.(check bool) "mentions code" true (string_contains r.message "418")
+  Alcotest.(check bool) "mentions code" true (string_contains_ci ~haystack:r.message ~needle:"418")
 
 (* ---- get_network_error_recovery ---- *)
 
@@ -238,19 +238,19 @@ let test_network_short () =
 
 let test_friendly_http () =
   let s = api_error_to_friendly_string (Http_error (401, "", None)) in
-  Alcotest.(check bool) "contains auth" true (string_contains s "Auth error")
+  Alcotest.(check bool) "contains auth" true (string_contains_ci ~haystack:s ~needle:"Auth error")
 
 let test_friendly_json () =
   let s = api_error_to_friendly_string (Json_error "bad json") in
-  Alcotest.(check bool) "contains json msg" true (string_contains s "bad json")
+  Alcotest.(check bool) "contains json msg" true (string_contains_ci ~haystack:s ~needle:"bad json")
 
 let test_friendly_network () =
   let s = api_error_to_friendly_string (Network_error "DNS failed") in
-  Alcotest.(check bool) "contains DNS" true (string_contains s "DNS")
+  Alcotest.(check bool) "contains DNS" true (string_contains_ci ~haystack:s ~needle:"DNS")
 
 let test_friendly_timeout () =
   let s = api_error_to_friendly_string Timeout_error in
-  Alcotest.(check bool) "contains timeout" true (string_contains s "timed out")
+  Alcotest.(check bool) "contains timeout" true (string_contains_ci ~haystack:s ~needle:"timed out")
 
 (* ---- truncate_body ---- *)
 
@@ -265,7 +265,7 @@ let test_truncate_201 () =
   let s = String.make 201 'x' in
   let result = truncate_body s in
   Alcotest.(check int) "length 203" 203 (String.length result);
-  Alcotest.(check bool) "ends with ..." true (string_contains result "...")
+  Alcotest.(check bool) "ends with ..." true (string_contains_ci ~haystack:result ~needle:"...")
 
 let test_truncate_empty () =
   Alcotest.(check string) "empty" "" (truncate_body "")

--- a/test/test_api_handlers_coverage.ml
+++ b/test/test_api_handlers_coverage.ml
@@ -55,27 +55,27 @@ let () =
   (* ============== string_contains ============== *)
   let test_string_contains_basic () =
     check bool "found" true
-      (Mcp_api_handlers.string_contains ~needle:"hello" ~haystack:"say hello world")
+      (Mcp_api_handlers.string_contains ~haystack:"say hello world" ~needle:"hello")
   in
   let test_string_contains_case () =
     check bool "case insensitive" true
-      (Mcp_api_handlers.string_contains ~needle:"HELLO" ~haystack:"hello world")
+      (Mcp_api_handlers.string_contains ~haystack:"hello world" ~needle:"HELLO")
   in
   let test_string_contains_not_found () =
     check bool "not found" false
-      (Mcp_api_handlers.string_contains ~needle:"xyz" ~haystack:"hello")
+      (Mcp_api_handlers.string_contains ~haystack:"hello" ~needle:"xyz")
   in
   let test_string_contains_empty_needle () =
     check bool "empty needle" false
-      (Mcp_api_handlers.string_contains ~needle:"" ~haystack:"hello")
+      (Mcp_api_handlers.string_contains ~haystack:"hello" ~needle:"")
   in
   let test_string_contains_empty_haystack () =
     check bool "empty haystack" false
-      (Mcp_api_handlers.string_contains ~needle:"a" ~haystack:"")
+      (Mcp_api_handlers.string_contains ~haystack:"" ~needle:"a")
   in
   let test_string_contains_needle_trim () =
     check bool "needle trimmed" true
-      (Mcp_api_handlers.string_contains ~needle:"  hello  " ~haystack:"hello world")
+      (Mcp_api_handlers.string_contains ~haystack:"hello world" ~needle:"  hello  ")
   in
 
   (* ============== matches_any ============== *)

--- a/test/test_api_protocol_w9.ml
+++ b/test/test_api_protocol_w9.ml
@@ -108,22 +108,22 @@ let test_api_error_to_string_http_long_body () =
   let body = String.make 1000 'A' in
   let s = api_error_to_string (Http_error (500, body, None)) in
   Alcotest.(check bool) "contains body_bytes"
-    true (string_contains s "body_bytes: 1000")
+    true (string_contains_ci ~haystack:s ~needle:"body_bytes: 1000")
 
 let test_api_error_to_string_http_empty_body () =
   let s = api_error_to_string (Http_error (200, "", None)) in
   Alcotest.(check bool) "body_bytes: 0"
-    true (string_contains s "body_bytes: 0")
+    true (string_contains_ci ~haystack:s ~needle:"body_bytes: 0")
 
 let test_api_error_to_string_json () =
   let s = api_error_to_string (Json_error "unexpected token") in
   Alcotest.(check bool) "JSON error prefix"
-    true (string_contains s "JSON error:")
+    true (string_contains_ci ~haystack:s ~needle:"JSON error:")
 
 let test_api_error_to_string_network () =
   let s = api_error_to_string (Network_error "ECONNREFUSED") in
   Alcotest.(check bool) "Network error prefix"
-    true (string_contains s "Network error:")
+    true (string_contains_ci ~haystack:s ~needle:"Network error:")
 
 let test_api_error_to_string_timeout () =
   let s = api_error_to_string Timeout_error in
@@ -144,7 +144,7 @@ let test_parse_http_response_not_chunked () =
   let status, body = parse_http_response response in
   Alcotest.(check int) "status" 200 status;
   Alcotest.(check bool) "body contains ok"
-    true (string_contains body "ok")
+    true (string_contains_ci ~haystack:body ~needle:"ok")
 
 let test_parse_http_response_transfer_encoding_not_chunked () =
   (* Transfer-Encoding header present but NOT chunked — the detection
@@ -336,23 +336,23 @@ let test_retry_delay_json () =
 
 let test_friendly_http_401 () =
   let s = api_error_to_friendly_string (Http_error (401, "", None)) in
-  Alcotest.(check bool) "contains Auth" true (string_contains s "Auth error")
+  Alcotest.(check bool) "contains Auth" true (string_contains_ci ~haystack:s ~needle:"Auth error")
 
 let test_friendly_http_429_with_body () =
   let s = api_error_to_friendly_string (Http_error (429, {|{"retry_after":10}|}, None)) in
-  Alcotest.(check bool) "contains Rate" true (string_contains s "Rate limited")
+  Alcotest.(check bool) "contains Rate" true (string_contains_ci ~haystack:s ~needle:"Rate limited")
 
 let test_friendly_json () =
   let s = api_error_to_friendly_string (Json_error "unexpected eof") in
-  Alcotest.(check bool) "contains Invalid" true (string_contains s "Invalid response")
+  Alcotest.(check bool) "contains Invalid" true (string_contains_ci ~haystack:s ~needle:"Invalid response")
 
 let test_friendly_network () =
   let s = api_error_to_friendly_string (Network_error "DNS: NXDOMAIN") in
-  Alcotest.(check bool) "contains DNS" true (string_contains s "DNS")
+  Alcotest.(check bool) "contains DNS" true (string_contains_ci ~haystack:s ~needle:"DNS")
 
 let test_friendly_timeout () =
   let s = api_error_to_friendly_string Timeout_error in
-  Alcotest.(check bool) "contains timed out" true (string_contains s "timed out")
+  Alcotest.(check bool) "contains timed out" true (string_contains_ci ~haystack:s ~needle:"timed out")
 
 (* ================================================================ *)
 (* figma_api_eio.ml — truncate_body edge cases                      *)
@@ -650,8 +650,8 @@ let test_with_query_empty () =
 let test_with_query_params () =
   let url = with_query "https://api.figma.com/v1/files/KEY"
     [("depth", ["2"]); ("version", ["v1"])] in
-  Alcotest.(check bool) "has depth" true (string_contains url "depth=2");
-  Alcotest.(check bool) "has version" true (string_contains url "version=v1")
+  Alcotest.(check bool) "has depth" true (string_contains_ci ~haystack:url ~needle:"depth=2");
+  Alcotest.(check bool) "has version" true (string_contains_ci ~haystack:url ~needle:"version=v1")
 
 (* ================================================================ *)
 (* figma_api_eio.ml — api_base constant                             *)
@@ -666,43 +666,43 @@ let test_api_base () =
 
 let test_suggestion_400_empty () =
   let s = suggestion_for_400 "" in
-  Alcotest.(check bool) "default suggestion" true (string_contains s "Invalid request")
+  Alcotest.(check bool) "default suggestion" true (string_contains_ci ~haystack:s ~needle:"Invalid request")
 
 let test_suggestion_400_invalid_id () =
   let s = suggestion_for_400 "invalid id format" in
-  Alcotest.(check bool) "invalid id" true (string_contains s "Invalid ID")
+  Alcotest.(check bool) "invalid id" true (string_contains_ci ~haystack:s ~needle:"Invalid ID")
 
 let test_suggestion_400_missing () =
   let s = suggestion_for_400 "missing parameter xyz" in
-  Alcotest.(check bool) "missing" true (string_contains s "Missing required")
+  Alcotest.(check bool) "missing" true (string_contains_ci ~haystack:s ~needle:"Missing required")
 
 let test_suggestion_400_node () =
   let s = suggestion_for_400 "node error encountered" in
-  Alcotest.(check bool) "node" true (string_contains s "Node-related")
+  Alcotest.(check bool) "node" true (string_contains_ci ~haystack:s ~needle:"Node-related")
 
 let test_suggestion_404_file () =
   let s = suggestion_for_404 "file not found" in
-  Alcotest.(check bool) "file" true (string_contains s "File not found")
+  Alcotest.(check bool) "file" true (string_contains_ci ~haystack:s ~needle:"File not found")
 
 let test_suggestion_404_node () =
   let s = suggestion_for_404 "node not found" in
-  Alcotest.(check bool) "node" true (string_contains s "Node not found")
+  Alcotest.(check bool) "node" true (string_contains_ci ~haystack:s ~needle:"Node not found")
 
 let test_suggestion_404_version () =
   let s = suggestion_for_404 "version not found" in
-  Alcotest.(check bool) "version" true (string_contains s "Version not found")
+  Alcotest.(check bool) "version" true (string_contains_ci ~haystack:s ~needle:"Version not found")
 
 let test_suggestion_404_empty () =
   let s = suggestion_for_404 "" in
-  Alcotest.(check bool) "default" true (string_contains s "Resource not found")
+  Alcotest.(check bool) "default" true (string_contains_ci ~haystack:s ~needle:"Resource not found")
 
 let test_suggestion_403_scope () =
   let s = suggestion_for_403 "file_variables:read is invalid scope" in
-  Alcotest.(check bool) "scope" true (string_contains s "scope")
+  Alcotest.(check bool) "scope" true (string_contains_ci ~haystack:s ~needle:"scope")
 
 let test_suggestion_403_generic () =
   let s = suggestion_for_403 "forbidden" in
-  Alcotest.(check bool) "permission" true (string_contains s "permission")
+  Alcotest.(check bool) "permission" true (string_contains_ci ~haystack:s ~needle:"permission")
 
 (* ================================================================ *)
 (* figma_api_eio.ml — body_contains, body_contains_any, first_match *)
@@ -849,7 +849,7 @@ let test_prompt_to_detail_json () =
 let test_mcp_instructions () =
   Alcotest.(check bool) "non-empty" true (String.length mcp_instructions > 100);
   Alcotest.(check bool) "contains Parse Don't Validate"
-    true (Figma_api_eio.string_contains mcp_instructions "Parse")
+    true (Figma_api_eio.string_contains_ci ~haystack:mcp_instructions ~needle:"Parse")
 
 (* ================================================================ *)
 (* mcp_protocol.ml — error codes                                    *)
@@ -906,18 +906,18 @@ let test_parse_request_valid () =
 let test_parse_request_no_version () =
   let json_str = {|{"id":1,"method":"test"}|} in
   match parse_request json_str with
-  | Error msg -> Alcotest.(check bool) "version error" true (Figma_api_eio.string_contains msg "version")
+  | Error msg -> Alcotest.(check bool) "version error" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"version")
   | Ok _ -> Alcotest.fail "should fail"
 
 let test_parse_request_no_method () =
   let json_str = {|{"jsonrpc":"2.0","id":1}|} in
   match parse_request json_str with
-  | Error msg -> Alcotest.(check bool) "method error" true (Figma_api_eio.string_contains msg "method")
+  | Error msg -> Alcotest.(check bool) "method error" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"method")
   | Ok _ -> Alcotest.fail "should fail"
 
 let test_parse_request_invalid_json () =
   match parse_request "not json" with
-  | Error msg -> Alcotest.(check bool) "JSON parse" true (Figma_api_eio.string_contains msg "JSON")
+  | Error msg -> Alcotest.(check bool) "JSON parse" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"JSON")
   | Ok _ -> Alcotest.fail "should fail"
 
 let test_parse_request_notification () =
@@ -1174,7 +1174,7 @@ let test_tools_call_handler_error () =
   match handle_tools_call_sync server (Some (`Assoc [("name", `String "fail_tool")])) with
   | Error (code, msg) ->
     Alcotest.(check int) "internal_error" internal_error code;
-    Alcotest.(check bool) "msg" true (Figma_api_eio.string_contains msg "handler failed")
+    Alcotest.(check bool) "msg" true (Figma_api_eio.string_contains_ci ~haystack:msg ~needle:"handler failed")
   | Ok _ -> Alcotest.fail "should fail"
 
 let test_tools_call_no_arguments_field () =

--- a/test/test_final_push_w8.ml
+++ b/test/test_final_push_w8.ml
@@ -27,14 +27,14 @@ let () =
 
   (* --- string_contains: case-insensitive substring match --- *)
   let test_string_contains_basic () =
-    check bool "exact" true (Mcp_tools.string_contains "hello" "hello");
-    check bool "prefix" true (Mcp_tools.string_contains "hello world" "hello");
-    check bool "suffix" true (Mcp_tools.string_contains "hello world" "world");
-    check bool "middle" true (Mcp_tools.string_contains "hello world" "lo wo");
-    check bool "case insensitive" true (Mcp_tools.string_contains "Hello World" "hello");
-    check bool "empty sub" true (Mcp_tools.string_contains "hello" "");
-    check bool "sub longer" false (Mcp_tools.string_contains "hi" "hello");
-    check bool "no match" false (Mcp_tools.string_contains "hello" "xyz")
+    check bool "exact" true (Mcp_helpers.string_contains ~haystack:"hello" ~needle:"hello");
+    check bool "prefix" true (Mcp_helpers.string_contains ~haystack:"hello world" ~needle:"hello");
+    check bool "suffix" true (Mcp_helpers.string_contains ~haystack:"hello world" ~needle:"world");
+    check bool "middle" true (Mcp_helpers.string_contains ~haystack:"hello world" ~needle:"lo wo");
+    check bool "case insensitive" true (Mcp_helpers.string_contains ~haystack:"Hello World" ~needle:"hello");
+    check bool "empty sub" false (Mcp_helpers.string_contains ~haystack:"hello" ~needle:"");
+    check bool "sub longer" false (Mcp_helpers.string_contains ~haystack:"hi" ~needle:"hello");
+    check bool "no match" false (Mcp_helpers.string_contains ~haystack:"hello" ~needle:"xyz")
   in
 
   (* --- is_network_error: Unix errors and string matching --- *)

--- a/test/test_mcp_tools_coverage.ml
+++ b/test/test_mcp_tools_coverage.ml
@@ -924,10 +924,10 @@ let server_tests = [
 (** ============== Main ============== *)
 
 let test_string_contains_basic () =
-  check bool "basic match" true (Mcp_tools.string_contains "Hello World" "world");
-  check bool "no match" false (Mcp_tools.string_contains "Hello" "bye");
-  check bool "empty sub" true (Mcp_tools.string_contains "Hello" "");
-  check bool "case insensitive" true (Mcp_tools.string_contains "BROKEN PIPE" "broken pipe")
+  check bool "basic match" true (Mcp_helpers.string_contains ~haystack:"Hello World" ~needle:"world");
+  check bool "no match" false (Mcp_helpers.string_contains ~haystack:"Hello" ~needle:"bye");
+  check bool "empty sub" false (Mcp_helpers.string_contains ~haystack:"Hello" ~needle:"");
+  check bool "case insensitive" true (Mcp_helpers.string_contains ~haystack:"BROKEN PIPE" ~needle:"broken pipe")
 
 let test_is_network_error_structural () =
   check bool "Unix EPIPE" true (Mcp_tools.is_network_error (Unix.Unix_error (Unix.EPIPE, "write", "")));
@@ -1049,8 +1049,8 @@ let test_make_category_tool_name () =
 let test_make_category_tool_description_contains_tools () =
   let cat : Mcp_tools.tool_category = { name = "mycat"; description = "My description"; tools = ["foo"; "bar"] } in
   let tool = Mcp_tools.make_category_tool cat in
-  check bool "description contains foo" true (Mcp_tools.string_contains tool.description "foo");
-  check bool "description contains bar" true (Mcp_tools.string_contains tool.description "bar")
+  check bool "description contains foo" true (Mcp_helpers.string_contains ~haystack:tool.description ~needle:"foo");
+  check bool "description contains bar" true (Mcp_helpers.string_contains ~haystack:tool.description ~needle:"bar")
 
 let test_make_category_tool_has_mode_enum () =
   let cat : Mcp_tools.tool_category = { name = "test"; description = "Test"; tools = ["x"] } in
@@ -1773,7 +1773,7 @@ let test_read_resource_tokens_docs () =
   | Ok (mime, body) ->
       check string "mime type" "text/markdown" mime;
       check bool "body not empty" true (String.length body > 0);
-      check bool "mentions Variables" true (Mcp_tools.string_contains body "variables")
+      check bool "mentions Variables" true (Mcp_helpers.string_contains ~haystack:body ~needle:"variables")
   | Error e -> fail ("read_resource tokens error: " ^ e)
 
 let test_read_resource_unknown_scheme () =
@@ -1799,31 +1799,31 @@ let resource_prompt_tests = [
 
 let test_string_contains_sub_longer_than_string () =
   check bool "sub longer" false
-    (Mcp_tools.string_contains "hi" "hello world")
+    (Mcp_helpers.string_contains ~haystack:"hi" ~needle:"hello world")
 
 let test_string_contains_equal_strings () =
   check bool "equal strings" true
-    (Mcp_tools.string_contains "hello" "hello")
+    (Mcp_helpers.string_contains ~haystack:"hello" ~needle:"hello")
 
 let test_string_contains_single_char () =
   check bool "single char match" true
-    (Mcp_tools.string_contains "abc" "b")
+    (Mcp_helpers.string_contains ~haystack:"abc" ~needle:"b")
 
 let test_string_contains_single_char_no_match () =
   check bool "single char no match" false
-    (Mcp_tools.string_contains "abc" "z")
+    (Mcp_helpers.string_contains ~haystack:"abc" ~needle:"z")
 
 let test_string_contains_at_end () =
   check bool "match at end" true
-    (Mcp_tools.string_contains "Hello World" "world")
+    (Mcp_helpers.string_contains ~haystack:"Hello World" ~needle:"world")
 
 let test_string_contains_at_start () =
   check bool "match at start" true
-    (Mcp_tools.string_contains "Hello World" "hello")
+    (Mcp_helpers.string_contains ~haystack:"Hello World" ~needle:"hello")
 
 let test_string_contains_mixed_case () =
   check bool "mixed case" true
-    (Mcp_tools.string_contains "aBcDeF" "BcDe")
+    (Mcp_helpers.string_contains ~haystack:"aBcDeF" ~needle:"BcDe")
 
 let string_contains_extra_tests = [
   "string_contains sub longer", `Quick, test_string_contains_sub_longer_than_string;

--- a/test/test_mcp_tools_extra.ml
+++ b/test/test_mcp_tools_extra.ml
@@ -11,22 +11,22 @@ open Mcp_helpers
    ============================================================ *)
 
 let test_string_contains_empty_sub () =
-  check bool "empty substring always true" true (string_contains "hello" "")
+  check bool "empty substring returns false" false (Mcp_helpers.string_contains ~haystack:"hello" ~needle:"")
 
 let test_string_contains_empty_string () =
-  check bool "non-empty sub in empty string" false (string_contains "" "a")
+  check bool "non-empty sub in empty string" false (Mcp_helpers.string_contains ~haystack:"" ~needle:"a")
 
 let test_string_contains_both_empty () =
-  check bool "both empty" true (string_contains "" "")
+  check bool "both empty" false (Mcp_helpers.string_contains ~haystack:"" ~needle:"")
 
 let test_string_contains_case_insensitive () =
-  check bool "case insensitive" true (string_contains "HelloWorld" "hELLO")
+  check bool "case insensitive" true (Mcp_helpers.string_contains ~haystack:"HelloWorld" ~needle:"hELLO")
 
 let test_string_contains_not_found () =
-  check bool "not found" false (string_contains "abc" "xyz")
+  check bool "not found" false (Mcp_helpers.string_contains ~haystack:"abc" ~needle:"xyz")
 
 let test_string_contains_partial_overlap () =
-  check bool "partial match at end" true (string_contains "abcxyz" "xyz")
+  check bool "partial match at end" true (Mcp_helpers.string_contains ~haystack:"abcxyz" ~needle:"xyz")
 
 let string_contains_tests = [
   "empty sub", `Quick, test_string_contains_empty_sub;
@@ -830,8 +830,8 @@ let test_handle_category_invalid_mode () =
      fail "expected Invalid_argument for invalid mode"
    with Invalid_argument msg ->
      check bool "mentions invalid" true
-       (Mcp_tools.string_contains msg "invalid" ||
-        Mcp_tools.string_contains msg "Invalid"))
+       (Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid" ||
+        Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid"))
 
 let test_handle_category_unknown_category () =
   let args = `Assoc [("mode", `String "list")] in
@@ -850,7 +850,7 @@ let test_handle_category_call_missing_args () =
   (match result with
    | Error msg ->
        check bool "mentions args" true
-         (Mcp_tools.string_contains msg "args")
+         (Mcp_helpers.string_contains ~haystack:msg ~needle:"args")
    | Ok _ -> fail "expected Error for missing args in call mode")
 
 let test_handle_category_call_with_args () =
@@ -905,7 +905,7 @@ let test_handle_parse_url_missing () =
   let args = `Assoc [] in
   let result = handle_parse_url args in
   (match result with
-   | Error msg -> check bool "mentions url" true (Mcp_tools.string_contains msg "url")
+   | Error msg -> check bool "mentions url" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"url")
    | Ok _ -> fail "expected Error")
 
 let test_handle_parse_url_valid () =
@@ -921,7 +921,7 @@ let test_handle_parse_url_with_node () =
   (match result with
    | Ok json ->
        let s = Yojson.Safe.to_string json in
-       check bool "contains file_key" true (Mcp_tools.string_contains s "ABC123")
+       check bool "contains file_key" true (Mcp_helpers.string_contains ~haystack:s ~needle:"ABC123")
    | Error msg -> fail (Printf.sprintf "expected Ok, got Error: %s" msg))
 
 let test_handle_get_me_no_token () =
@@ -932,7 +932,7 @@ let test_handle_get_me_no_token () =
   let result = handle_get_me args in
   (match saved with Some v -> Unix.putenv "FIGMA_TOKEN" v | None -> ());
   (match result with
-   | Error msg -> check bool "mentions token" true (Mcp_tools.string_contains msg "token")
+   | Error msg -> check bool "mentions token" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"token")
    | Ok _ -> (* If FIGMA_TOKEN was set globally, this might succeed through Effect *) ())
 
 let test_handle_list_projects_missing () =
@@ -995,7 +995,7 @@ let test_handle_crawl_team_missing_team () =
   let args = `Assoc [] in
   let result = handle_crawl_team args in
   (match result with
-   | Error msg -> check bool "mentions team_id" true (Mcp_tools.string_contains msg "team_id")
+   | Error msg -> check bool "mentions team_id" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"team_id")
    | Ok _ -> fail "expected Error")
 
 let test_handle_crawl_team_missing_token () =
@@ -1005,14 +1005,14 @@ let test_handle_crawl_team_missing_token () =
   let result = handle_crawl_team args in
   (match saved with Some v -> Unix.putenv "FIGMA_TOKEN" v | None -> ());
   (match result with
-   | Error msg -> check bool "mentions token" true (Mcp_tools.string_contains msg "token")
+   | Error msg -> check bool "mentions token" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"token")
    | Ok _ -> ())
 
 let test_handle_team_tree_missing_team () =
   let args = `Assoc [] in
   let result = handle_team_tree args in
   (match result with
-   | Error msg -> check bool "mentions team_id" true (Mcp_tools.string_contains msg "team_id")
+   | Error msg -> check bool "mentions team_id" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"team_id")
    | Ok _ -> fail "expected Error")
 
 let test_handle_team_tree_missing_token () =
@@ -1022,14 +1022,14 @@ let test_handle_team_tree_missing_token () =
   let result = handle_team_tree args in
   (match saved with Some v -> Unix.putenv "FIGMA_TOKEN" v | None -> ());
   (match result with
-   | Error msg -> check bool "mentions token" true (Mcp_tools.string_contains msg "token")
+   | Error msg -> check bool "mentions token" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"token")
    | Ok _ -> ())
 
 let test_handle_export_team_missing_team () =
   let args = `Assoc [] in
   let result = handle_export_team args in
   (match result with
-   | Error msg -> check bool "mentions team_id" true (Mcp_tools.string_contains msg "team_id")
+   | Error msg -> check bool "mentions team_id" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"team_id")
    | Ok _ -> fail "expected Error")
 
 let test_handle_export_team_missing_token () =
@@ -1039,14 +1039,14 @@ let test_handle_export_team_missing_token () =
   let result = handle_export_team args in
   (match saved with Some v -> Unix.putenv "FIGMA_TOKEN" v | None -> ());
   (match result with
-   | Error msg -> check bool "mentions token" true (Mcp_tools.string_contains msg "token")
+   | Error msg -> check bool "mentions token" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"token")
    | Ok _ -> ())
 
 let test_handle_export_team_missing_output_dir () =
   let args = `Assoc [("team_id", `String "12345"); ("token", `String "faketoken")] in
   let result = handle_export_team args in
   (match result with
-   | Error msg -> check bool "mentions output_dir" true (Mcp_tools.string_contains msg "output_dir")
+   | Error msg -> check bool "mentions output_dir" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"output_dir")
    | Ok _ -> fail "expected Error")
 
 let handler_error_tests = [
@@ -1079,7 +1079,7 @@ let test_handle_codegen_sync_missing_json () =
   let args = `Assoc [] in
   let result = handle_codegen_sync args in
   (match result with
-   | Error msg -> check bool "mentions json" true (Mcp_tools.string_contains msg "json")
+   | Error msg -> check bool "mentions json" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"json")
    | Ok _ -> fail "expected Error")
 
 let test_handle_codegen_sync_invalid_json () =
@@ -1104,7 +1104,7 @@ let test_wrap_sync_pure_no_eio () =
   let wrapped = wrap_sync_pure handler in
   let result = wrapped (`Assoc []) in
   (match result with
-   | Error msg -> check bool "mentions Eio" true (Mcp_tools.string_contains msg "Eio")
+   | Error msg -> check bool "mentions Eio" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"Eio")
    | Ok _ -> fail "expected Error without Eio context")
 
 let wrap_sync_tests = [
@@ -1119,7 +1119,7 @@ let test_handle_read_large_result_missing_path () =
   let args = `Assoc [] in
   let result = handle_read_large_result args in
   (match result with
-   | Error msg -> check bool "mentions file_path" true (Mcp_tools.string_contains msg "file_path")
+   | Error msg -> check bool "mentions file_path" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"file_path")
    | Ok _ -> fail "expected Error")
 
 let test_handle_read_large_result_outside_dir () =
@@ -1153,7 +1153,7 @@ let test_handle_cache_invalidate_all () =
   (match result with
    | Ok json ->
        let s = Yojson.Safe.to_string json in
-       check bool "all cache" true (Mcp_tools.string_contains s "All cache")
+       check bool "all cache" true (Mcp_helpers.string_contains ~haystack:s ~needle:"All cache")
    | Error msg -> fail msg)
 
 let test_handle_cache_invalidate_file_only () =
@@ -1162,7 +1162,7 @@ let test_handle_cache_invalidate_file_only () =
   (match result with
    | Ok json ->
        let s = Yojson.Safe.to_string json in
-       check bool "mentions file" true (Mcp_tools.string_contains s "ABC123")
+       check bool "mentions file" true (Mcp_helpers.string_contains ~haystack:s ~needle:"ABC123")
    | Error msg -> fail msg)
 
 let test_handle_cache_invalidate_file_and_node () =
@@ -1171,7 +1171,7 @@ let test_handle_cache_invalidate_file_and_node () =
   (match result with
    | Ok json ->
        let s = Yojson.Safe.to_string json in
-       check bool "mentions node" true (Mcp_tools.string_contains s "1:2")
+       check bool "mentions node" true (Mcp_helpers.string_contains ~haystack:s ~needle:"1:2")
    | Error msg -> fail msg)
 
 let cache_invalidate_tests = [
@@ -1188,14 +1188,14 @@ let test_handle_code_connect_empty_mode () =
   let args = `Assoc [] in
   let result = handle_code_connect args in
   (match result with
-   | Error msg -> check bool "mentions mode" true (Mcp_tools.string_contains msg "mode")
+   | Error msg -> check bool "mentions mode" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"mode")
    | Ok _ -> fail "expected Error")
 
 let test_handle_code_connect_unknown_mode () =
   let args = `Assoc [("mode", `String "bogus")] in
   let result = handle_code_connect args in
   (match result with
-   | Error msg -> check bool "mentions unknown" true (Mcp_tools.string_contains msg "nknown")
+   | Error msg -> check bool "mentions unknown" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"nknown")
    | Ok _ -> fail "expected Error")
 
 let test_handle_code_connect_validate_no_source () =
@@ -1218,7 +1218,7 @@ let test_handle_code_connect_validate_invalid_json () =
   let args = `Assoc [("mode", `String "validate"); ("json", `String "not json{")] in
   let result = handle_code_connect args in
   (match result with
-   | Error msg -> check bool "mentions JSON" true (Mcp_tools.string_contains msg "JSON")
+   | Error msg -> check bool "mentions JSON" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"JSON")
    | Ok _ -> fail "expected Error for invalid JSON")
 
 let test_handle_code_connect_index_inline () =
@@ -1228,7 +1228,7 @@ let test_handle_code_connect_index_inline () =
   (match result with
    | Ok json ->
        let s = Yojson.Safe.to_string json in
-       check bool "has index_id" true (Mcp_tools.string_contains s "index_id")
+       check bool "has index_id" true (Mcp_helpers.string_contains ~haystack:s ~needle:"index_id")
    | Error _ -> ())
 
 let test_handle_code_connect_list_no_source () =
@@ -1252,7 +1252,7 @@ let test_handle_code_connect_match_bad_index () =
   ] in
   let result = handle_code_connect args in
   (match result with
-   | Error msg -> check bool "mentions index_id" true (Mcp_tools.string_contains msg "index_id")
+   | Error msg -> check bool "mentions index_id" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"index_id")
    | Ok _ -> fail "expected Error")
 
 let code_connect_tests = [
@@ -1311,7 +1311,7 @@ let test_read_resource_tokens_empty_file_key () =
   (try Unix.putenv "FIGMA_TOKEN" "test_token" with _ -> ());
   let result = read_resource "figma://tokens/" in
   (match result with
-   | Error msg -> check bool "mentions file_key" true (Mcp_tools.string_contains msg "file_key")
+   | Error msg -> check bool "mentions file_key" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"file_key")
    | Ok _ -> fail "expected Error for empty file_key")
 
 let test_read_resource_tokens_with_query () =
@@ -1481,8 +1481,8 @@ let test_handle_doctor () =
   (match result with
    | Ok json ->
        let s = Yojson.Safe.to_string json in
-       check bool "has checks" true (Mcp_tools.string_contains s "checks");
-       check bool "has status" true (Mcp_tools.string_contains s "status")
+       check bool "has checks" true (Mcp_helpers.string_contains ~haystack:s ~needle:"checks");
+       check bool "has status" true (Mcp_helpers.string_contains ~haystack:s ~needle:"status")
    | Error msg -> fail msg)
 
 let doctor_tests = [

--- a/test/test_mcp_tools_w6.ml
+++ b/test/test_mcp_tools_w6.ml
@@ -1030,7 +1030,7 @@ let test_read_resource_tokens_empty_key () =
   (match result with
    | Error msg ->
        check bool "mentions file_key" true
-         (string_contains msg "file_key" || string_contains msg "missing")
+         (Mcp_helpers.string_contains ~haystack:msg ~needle:"file_key" || Mcp_helpers.string_contains ~haystack:msg ~needle:"missing")
    | Ok _ -> ())
 
 (* tokens template with query params — exercises split_query + format extraction.
@@ -1077,7 +1077,7 @@ let read_resource_extra_tests = [
 let test_handle_codegen_sync_missing_json () =
   let args = `Assoc [] in
   match handle_codegen_sync args with
-  | Error msg -> check bool "mentions json" true (string_contains msg "json")
+  | Error msg -> check bool "mentions json" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"json")
   | Ok _ -> fail "Expected Error for missing json"
 
 let test_handle_codegen_sync_invalid_json () =
@@ -1120,7 +1120,7 @@ let test_handle_parse_url_design_url () =
   match handle_parse_url args with
   | Ok json ->
       let s = Yojson.Safe.to_string json in
-      check bool "contains file_key" true (string_contains s "ABC123")
+      check bool "contains file_key" true (Mcp_helpers.string_contains ~haystack:s ~needle:"ABC123")
   | Error _ -> ()  (* Might fail if URL format not recognized *)
 
 let test_handle_parse_url_proto_url () =
@@ -1136,7 +1136,7 @@ let test_handle_parse_url_non_figma () =
   match handle_parse_url args with
   | Ok json ->
       let s = Yojson.Safe.to_string json in
-      check bool "has none markers" true (string_contains s "none")
+      check bool "has none markers" true (Mcp_helpers.string_contains ~haystack:s ~needle:"none")
   | Error _ -> ()
 
 let test_handle_parse_url_empty_string () =
@@ -1200,7 +1200,7 @@ let test_make_category_tool_structure () =
   let tool = make_category_tool cat in
   check string "name" "figma_test_cat" tool.name;
   check bool "description has tools" true
-    (string_contains tool.description "a, b");
+    (Mcp_helpers.string_contains ~haystack:tool.description ~needle:"a, b");
   (match tool.input_schema with
    | `Assoc _ -> ()
    | _ -> fail "Expected object schema")
@@ -1295,16 +1295,16 @@ let network_error_extra_tests = [
    ============================================================ *)
 
 let test_string_contains_repeated () =
-  check bool "repeated pattern" true (string_contains "ababab" "bab")
+  check bool "repeated pattern" true (Mcp_helpers.string_contains ~haystack:"ababab" ~needle:"bab")
 
 let test_string_contains_unicode () =
-  check bool "unicode haystack" true (string_contains "hello\xc3\xa9world" "world")
+  check bool "unicode haystack" true (Mcp_helpers.string_contains ~haystack:"hello\xc3\xa9world" ~needle:"world")
 
 let test_string_contains_single_char_both () =
-  check bool "single char both" true (string_contains "a" "a")
+  check bool "single char both" true (Mcp_helpers.string_contains ~haystack:"a" ~needle:"a")
 
 let test_string_contains_single_char_mismatch () =
-  check bool "single char mismatch" false (string_contains "a" "b")
+  check bool "single char mismatch" false (Mcp_helpers.string_contains ~haystack:"a" ~needle:"b")
 
 let string_contains_extra_tests = [
   "repeated pattern", `Quick, test_string_contains_repeated;
@@ -1398,11 +1398,11 @@ let test_handle_category_invalid_mode_caught () =
   (try
     match handle_category "core" args with
     | Error msg ->
-        check bool "mentions invalid" true (string_contains msg "invalid" || string_contains msg "Invalid")
+        check bool "mentions invalid" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid" || Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid")
     | Ok _ -> fail "Expected Error for invalid mode"
    with
    | Invalid_argument msg ->
-       check bool "mentions invalid" true (string_contains msg "Invalid" || string_contains msg "invalid")
+       check bool "mentions invalid" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid" || Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid")
    | exn ->
        (* Other exception: still acceptable, the branch was exercised *)
        check bool "exception raised" true (String.length (Printexc.to_string exn) > 0))
@@ -1422,14 +1422,14 @@ let test_handle_cache_invalidate_all () =
   match handle_cache_invalidate (`Assoc []) with
   | Ok json ->
       let s = Yojson.Safe.to_string json in
-      check bool "mentions all" true (string_contains s "All" || string_contains s "all")
+      check bool "mentions all" true (Mcp_helpers.string_contains ~haystack:s ~needle:"All" || Mcp_helpers.string_contains ~haystack:s ~needle:"all")
   | Error msg -> fail ("Unexpected error: " ^ msg)
 
 let test_handle_cache_invalidate_file_only () =
   match handle_cache_invalidate (`Assoc [("file_key", `String "ABC123")]) with
   | Ok json ->
       let s = Yojson.Safe.to_string json in
-      check bool "mentions file" true (string_contains s "ABC123")
+      check bool "mentions file" true (Mcp_helpers.string_contains ~haystack:s ~needle:"ABC123")
   | Error msg -> fail ("Unexpected error: " ^ msg)
 
 let test_handle_cache_invalidate_file_and_node () =
@@ -1439,7 +1439,7 @@ let test_handle_cache_invalidate_file_and_node () =
   ]) with
   | Ok json ->
       let s = Yojson.Safe.to_string json in
-      check bool "mentions node" true (string_contains s "1:2")
+      check bool "mentions node" true (Mcp_helpers.string_contains ~haystack:s ~needle:"1:2")
   | Error msg -> fail ("Unexpected error: " ^ msg)
 
 let cache_invalidate_tests = [
@@ -1469,8 +1469,8 @@ let test_handle_doctor_basic () =
   match handle_doctor (`Assoc []) with
   | Ok json ->
       let s = Yojson.Safe.to_string json in
-      check bool "has status" true (string_contains s "status");
-      check bool "has checks" true (string_contains s "checks")
+      check bool "has status" true (Mcp_helpers.string_contains ~haystack:s ~needle:"status");
+      check bool "has checks" true (Mcp_helpers.string_contains ~haystack:s ~needle:"checks")
   | Error msg -> fail ("Unexpected error: " ^ msg)
 
 let doctor_tests = [

--- a/test/test_tools_a5.ml
+++ b/test/test_tools_a5.ml
@@ -898,13 +898,13 @@ let test_is_under_dir_nonexistent () =
    ============================================================ *)
 
 let test_string_contains_found () =
-  check bool "found" true (Mcp_tools.string_contains "Hello World" "world")
+  check bool "found" true (Mcp_helpers.string_contains ~haystack:"Hello World" ~needle:"world")
 
 let test_string_contains_not_found () =
-  check bool "not found" false (Mcp_tools.string_contains "Hello World" "xyz")
+  check bool "not found" false (Mcp_helpers.string_contains ~haystack:"Hello World" ~needle:"xyz")
 
 let test_string_contains_empty_sub () =
-  check bool "empty sub" true (Mcp_tools.string_contains "anything" "")
+  check bool "empty sub" false (Mcp_helpers.string_contains ~haystack:"anything" ~needle:"")
 
 let test_is_network_error_epipe () =
   check bool "epipe" true


### PR DESCRIPTION
## Summary

- 3개 중복 `string_contains` 구현을 `Mcp_helpers.string_contains`로 통합 (labeled args, case-insensitive, `Str.regexp_string` 기반)
- `figma_api_eio.ml`은 순환 의존성으로 인해 로컬 `string_contains_ci` 유지 (동일 구현)
- 3개 DEPRECATED 데드코드 tool 정의 제거 (`compare_regions`, `evolution_report`, `compare_elements`)
- `Bytes.unsafe_to_string` → `Bytes.to_string` 교체 (`mcp_agent_queue.ml`)
- 빈 needle → `false` 반환으로 동작 통일 (Parse Don't Validate)
- 9개 테스트 파일 (261 호출 사이트) 시그니처 업데이트

## Changes

| File | Change |
|------|--------|
| `mcp_helpers.ml/mli` | `string_contains`, `matches_any`, `find_matching_pattern` 추가 |
| `mcp_tools.ml` | 로컬 `string_contains` 제거 + 3개 dead tool 삭제 (-82줄) |
| `figma_api_eio.ml` | `string_contains` → `string_contains_ci` (labeled args) |
| `mcp_api_handlers.ml/mli` | `Mcp_helpers`로 위임, label 순서 수정 |
| `mcp_agent_queue.ml` | `unsafe_to_string` → `to_string` |
| 9 test files | 261 call sites 시그니처 업데이트 |

## Net impact
16 files, +224 -259 (net -35 lines)

## Test plan
- [x] `dune build --root .` 성공
- [x] `dune test --root .` 전체 통과 (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)