### PR TITLE
refactor: hoist Str.regexp to module top-level

### DIFF
--- a/lib/figma_api.ml
+++ b/lib/figma_api.ml
@@ -4,15 +4,18 @@ open Printf
 
 (** ============== Node ID 변환 ============== *)
 
+let re_dash = Str.regexp "-"
+let re_colon = Str.regexp ":"
+
 (** URL 형식 (2089-11127) → API 형식 (2089:11127)
     Figma URL에서 추출한 node-id를 API 호출용으로 변환 *)
 let url_to_api_node_id id =
-  Str.global_replace (Str.regexp "-") ":" id
+  Str.global_replace re_dash ":" id
 
 (** API 형식 (2089:11127) → URL 형식 (2089-11127)
     API 응답의 node id를 URL용으로 변환 *)
 let api_to_url_node_id id =
-  Str.global_replace (Str.regexp ":") "-" id
+  Str.global_replace re_colon "-" id
 
 (** Normalize node ID input. Convert hyphen form when colon is missing. *)
 let normalize_node_id id =

--- a/lib/figma_tokens.ml
+++ b/lib/figma_tokens.ml
@@ -2,6 +2,9 @@
 
 open Figma_types
 
+let re_dash = Str.regexp "-"
+let re_space = Str.regexp " "
+
 (** ============== 토큰 타입 ============== *)
 
 type color_token = {
@@ -74,7 +77,7 @@ let extract_typography nodes =
         else begin
           Hashtbl.add seen key true;
           let name = Printf.sprintf "text-%s-%d"
-            (String.lowercase_ascii (Str.global_replace (Str.regexp " ") "-" t.font_family))
+            (String.lowercase_ascii (Str.global_replace re_space "-" t.font_family))
             (int_of_float t.font_size)
           in
           Some {
@@ -238,7 +241,7 @@ let to_swiftui tokens =
   (* Colors *)
   Buffer.add_string lines "// MARK: - Colors\nextension Color {\n";
   List.iter (fun (c: color_token) ->
-    let name = Str.global_replace (Str.regexp "-") "_" c.name in
+    let name = Str.global_replace re_dash "_" c.name in
     Buffer.add_string lines (Printf.sprintf "    static let %s = Color(hex: \"%s\")\n" name c.hex)
   ) tokens.colors;
   Buffer.add_string lines "}\n\n";
@@ -262,7 +265,7 @@ let to_swiftui tokens =
   (* Typography *)
   Buffer.add_string lines "// MARK: - Typography\nenum Typography {\n";
   List.iter (fun (t: typography_token) ->
-    let name = Str.global_replace (Str.regexp "-") "_" t.name in
+    let name = Str.global_replace re_dash "_" t.name in
     let weight = match t.font_weight with
       | w when w >= 700 -> "bold"
       | w when w >= 500 -> "medium"
@@ -284,7 +287,7 @@ let to_compose tokens =
   (* Colors *)
   Buffer.add_string lines "object AppColors {\n";
   List.iter (fun (c: color_token) ->
-    let name = Str.global_replace (Str.regexp "-") "" c.name |> String.capitalize_ascii in
+    let name = Str.global_replace re_dash "" c.name |> String.capitalize_ascii in
     let hex = String.sub c.hex 1 6 in
     Buffer.add_string lines (Printf.sprintf "    val %s = Color(0xFF%s)\n" name (String.uppercase_ascii hex))
   ) tokens.colors;
@@ -309,7 +312,7 @@ let to_compose tokens =
   (* Typography *)
   Buffer.add_string lines "object AppTypography {\n";
   List.iter (fun (t: typography_token) ->
-    let name = Str.global_replace (Str.regexp "-") "" t.name |> String.capitalize_ascii in
+    let name = Str.global_replace re_dash "" t.name |> String.capitalize_ascii in
     let weight = match t.font_weight with
       | w when w >= 700 -> "Bold"
       | w when w >= 500 -> "Medium"
@@ -330,7 +333,7 @@ let to_flutter tokens =
   (* Colors *)
   Buffer.add_string lines "class AppColors {\n  AppColors._();\n\n";
   List.iter (fun (c: color_token) ->
-    let name = Str.global_replace (Str.regexp "-") "" c.name in
+    let name = Str.global_replace re_dash "" c.name in
     let name = String.mapi (fun i c -> if i = 0 then Char.lowercase_ascii c else c) name in
     let hex = String.sub c.hex 1 6 in
     Buffer.add_string lines (Printf.sprintf "  static const %s = Color(0xFF%s);\n" name (String.uppercase_ascii hex))
@@ -357,7 +360,7 @@ let to_flutter tokens =
   (* Typography *)
   Buffer.add_string lines "class AppTextStyles {\n  AppTextStyles._();\n\n";
   List.iter (fun (t: typography_token) ->
-    let name = Str.global_replace (Str.regexp "-") "" t.name in
+    let name = Str.global_replace re_dash "" t.name in
     let name = String.mapi (fun i c -> if i = 0 then Char.lowercase_ascii c else c) name in
     let weight = match t.font_weight with
       | w when w >= 700 -> "w700"

--- a/lib/semantic_verifier.ml
+++ b/lib/semantic_verifier.ml
@@ -55,8 +55,10 @@ type t = {
   mismatches: mismatch list;
 }
 
+let re_whitespace = Str.regexp "[ \t\n\r]+"
+
 let normalize_text s =
-  let s = Str.global_replace (Str.regexp "[ \t\n\r]+") " " s in
+  let s = Str.global_replace re_whitespace " " s in
   String.trim s
 
 let rgba_dist_rgb (a: rgba) (b: rgba) : float =

--- a/lib/text_verifier.ml
+++ b/lib/text_verifier.ml
@@ -5,6 +5,17 @@
 
 open Figma_types
 
+let re_script = Str.regexp "<script[^>]*>.*?</script>"
+let re_style = Str.regexp "<style[^>]*>.*?</style>"
+let re_tag = Str.regexp "<[^>]*>"
+let re_nbsp = Str.regexp_string "&nbsp;"
+let re_lt = Str.regexp_string "&lt;"
+let re_gt = Str.regexp_string "&gt;"
+let re_amp = Str.regexp_string "&amp;"
+let re_quot = Str.regexp_string "&quot;"
+let re_whitespace_lines = Str.regexp "[\n\r\t]+"
+let re_whitespace = Str.regexp "[ \t\n\r]+"
+
 (** 텍스트 비교 결과 *)
 type text_match = {
   dsl_text: string;      (** DSL에서 추출한 텍스트 *)
@@ -33,21 +44,21 @@ let rec extract_texts_from_node (node: ui_node) : string list =
 (** HTML에서 텍스트 추출 (간단한 태그 제거) *)
 let extract_texts_from_html (html: string) : string list =
   (* 1. script, style 태그 내용 제거 *)
-  let html = Str.global_replace (Str.regexp "<script[^>]*>.*?</script>") "" html in
-  let html = Str.global_replace (Str.regexp "<style[^>]*>.*?</style>") "" html in
+  let html = Str.global_replace re_script "" html in
+  let html = Str.global_replace re_style "" html in
 
   (* 2. HTML 태그 제거 *)
-  let html = Str.global_replace (Str.regexp "<[^>]*>") "\n" html in
+  let html = Str.global_replace re_tag "\n" html in
 
   (* 3. HTML 엔티티 디코딩 *)
-  let html = Str.global_replace (Str.regexp_string "&nbsp;") " " html in
-  let html = Str.global_replace (Str.regexp_string "&lt;") "<" html in
-  let html = Str.global_replace (Str.regexp_string "&gt;") ">" html in
-  let html = Str.global_replace (Str.regexp_string "&amp;") "&" html in
-  let html = Str.global_replace (Str.regexp_string "&quot;") "\"" html in
+  let html = Str.global_replace re_nbsp " " html in
+  let html = Str.global_replace re_lt "<" html in
+  let html = Str.global_replace re_gt ">" html in
+  let html = Str.global_replace re_amp "&" html in
+  let html = Str.global_replace re_quot "\"" html in
 
   (* 4. 줄바꿈/공백으로 분리하고 빈 문자열 제거 *)
-  let parts = Str.split (Str.regexp "[\n\r\t]+") html in
+  let parts = Str.split re_whitespace_lines html in
   List.filter_map (fun s ->
     let trimmed = String.trim s in
     if String.length trimmed > 0 then Some trimmed else None
@@ -56,7 +67,7 @@ let extract_texts_from_html (html: string) : string list =
 (** 텍스트 정규화 (비교용) *)
 let normalize_text (s: string) : string =
   (* 공백 정규화: 연속 공백 → 단일 공백 *)
-  let s = Str.global_replace (Str.regexp "[ \t\n\r]+") " " s in
+  let s = Str.global_replace re_whitespace " " s in
   String.trim s
 
 (** DSL 텍스트가 HTML 텍스트 목록에 존재하는지 확인 *)


### PR DESCRIPTION
## Summary
- `Str.regexp` 호출을 함수 내부에서 모듈 최상위로 hoisting하여 불필요한 정규식 재컴파일 제거
- 4개 파일, 21개 사이트에서 인라인 `Str.regexp` → 모듈 top-level `let re_*` 변환
- 동적 패턴(`Str.regexp_string` with runtime values)은 hoisting 불가하므로 의도적으로 유지

## Changed files
| File | Sites | Hoisted vars |
|------|-------|-------------|
| `figma_tokens.ml` | 8 | `re_dash`, `re_space` |
| `text_verifier.ml` | 10 | `re_script`, `re_style`, `re_tag`, `re_nbsp`, `re_lt`, `re_gt`, `re_amp`, `re_quot`, `re_whitespace_lines`, `re_whitespace` |
| `semantic_verifier.ml` | 1 | `re_whitespace` |
| `figma_api.ml` | 2 | `re_dash`, `re_colon` |

## Context
Simplify Round 2 — efficiency review에서 발견된 `Str.regexp` 반복 컴파일 문제 해결.
Round 1 (PR #137)에서는 `string_contains` 통합, dead code 제거, `unsafe_to_string` 교체를 수행.

## Test plan
- [x] `dune build` 성공
- [x] `dune test` 전체 28개 테스트 통과
- [x] 인라인 `Str.regexp` 잔여 확인 — 동적 패턴 2개만 의도적 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)