### PR TITLE
fix: QA AS1 bug fixes (#151-#157)

### DIFF
--- a/lib/mcp_helpers.ml
+++ b/lib/mcp_helpers.ml
@@ -365,7 +365,13 @@ let resolve_token args =
      request-provided tokens to override it. This avoids accidental/abusive
      secret injection via tool args (e.g., MCP clients or logs). *)
   match Sys.getenv_opt "FIGMA_TOKEN" with
-  | Some t when String.length t > 0 -> Some t
+  | Some t when String.length t > 0 ->
+      (match get_string "token" args with
+       | Some _ ->
+           Printf.eprintf "[figma-mcp] Warning: explicit token parameter ignored \
+             (FIGMA_TOKEN env takes precedence for security)\n%!"
+       | None -> ());
+      Some t
   | _ ->
     match get_string "token" args with
     | Some t when String.length t > 0 ->

--- a/lib/mcp_protocol_router.ml
+++ b/lib/mcp_protocol_router.ml
@@ -7,6 +7,7 @@ let is_public_path meth path =
   match (meth, path) with
   | (`OPTIONS, _) -> true
   | (`GET, "/health") -> true
+  | (`GET, "/metrics") -> true
   | _ -> false
 
 let normalize_env value =

--- a/lib/mcp_sdk_adapter_figma.ml
+++ b/lib/mcp_sdk_adapter_figma.ml
@@ -71,6 +71,7 @@ let sdk_tool_of_local (tool : Figma_mcp_protocol.tool_def) : MT.tool =
     input_schema = tool.input_schema;
     title = None;
     annotations = None;
+    icon = None;
   }
 
 let sdk_resource_of_local (resource : Figma_mcp_protocol.mcp_resource) : MT.resource =
@@ -79,6 +80,7 @@ let sdk_resource_of_local (resource : Figma_mcp_protocol.mcp_resource) : MT.reso
     name = resource.name;
     description = Some resource.description;
     mime_type = Some resource.mime_type;
+    icon = None;
   }
 
 let sdk_resource_template_of_local
@@ -88,6 +90,7 @@ let sdk_resource_template_of_local
     name = template.name;
     description = Some template.description;
     mime_type = Some template.mime_type;
+    icon = None;
   }
 
 let sdk_prompt_of_local (prompt : Figma_mcp_protocol.mcp_prompt) : MT.prompt =
@@ -102,6 +105,7 @@ let sdk_prompt_of_local (prompt : Figma_mcp_protocol.mcp_prompt) : MT.prompt =
     name = prompt.name;
     description = Some prompt.description;
     arguments = Some (List.map sdk_arg_of_local prompt.arguments);
+    icon = None;
   }
 
 let normalize_local_tool_result json =

--- a/lib/mcp_tool_defs.ml
+++ b/lib/mcp_tool_defs.ml
@@ -756,7 +756,10 @@ let tool_categories = [
   { name = "components";
     description = "컴포넌트/스타일/변수";
     tools = ["get_file_components"; "get_file_component_sets"; "get_file_styles";
-             "get_component"; "get_component_set"; "get_style"; "get_variables"; "code_connect"] };
+             "get_component"; "get_component_set"; "get_variables"] };
+  { name = "code";
+    description = "코드 생성/연결";
+    tools = ["codegen"; "code_connect"] };
 ]
 
 (** 카테고리에서 도구 찾기 *)

--- a/lib/mcp_tool_handlers.ml
+++ b/lib/mcp_tool_handlers.ml
@@ -1347,22 +1347,21 @@ let handle_category category_name args =
     List.find_opt (fun (t : tool_def) -> t.name = full_name) all_detailed_tools
   in
 
-  let effective_mode : [ `List | `Describe | `Call ] =
-    match mode_param with
-    | Some "list" -> `List
-    | Some "describe" -> `Describe
-    | Some "call" -> `Call
-    | Some other ->
-        (* Fail fast for invalid modes: prevents accidental calls when user mistypes. *)
-        raise (Invalid_argument (sprintf "Invalid mode: %s (use list|describe|call)" other))
-    | None ->
-        match tool_param, args_param with
-        | None, _ -> `List
-        | Some _, None -> `Describe
-        | Some _, Some _ -> `Call
-  in
-
   try
+    let effective_mode : [ `List | `Describe | `Call ] =
+      match mode_param with
+      | Some "list" -> `List
+      | Some "describe" -> `Describe
+      | Some "call" -> `Call
+      | Some other ->
+          raise (Invalid_argument (sprintf "Invalid mode: %s (use list|describe|call)" other))
+      | None ->
+          match tool_param, args_param with
+          | None, _ -> `List
+          | Some _, None -> `Describe
+          | Some _, Some _ -> `Call
+    in
+
     match effective_mode with
     | `List ->
         (match List.find_opt (fun c -> c.name = category_name) tool_categories with
@@ -1433,10 +1432,24 @@ let handle_category category_name args =
                match Hashtbl.find_opt handler_registry full_name with
                | Some handler ->
                    (match args_param with
-                    | None ->
-                        Error "Missing required parameter: args (mode=call)"
                     | Some actual_args ->
-                        handler actual_args)
+                        handler actual_args
+                    | None ->
+                        (* Flat params fallback: mode/tool을 제외한 나머지를 args로 취급 *)
+                        let implicit_args =
+                          match args with
+                          | `Assoc pairs ->
+                              let filtered = List.filter (fun (k, _) ->
+                                k <> "mode" && k <> "tool") pairs in
+                              if filtered = [] then None
+                              else Some (`Assoc filtered)
+                          | _ -> None
+                        in
+                        (match implicit_args with
+                         | Some actual_args -> handler actual_args
+                         | None ->
+                             Error (sprintf "Missing required parameter: args (mode=call). \
+                               Usage: figma_%s mode=call tool=%s args={...}" category_name tool_name)))
                | None ->
                    Error (sprintf "Tool '%s' exists but handler not found. Try 'figma_%s' directly." tool_name tool_name))
   with

--- a/lib/mcp_tool_registry.ml
+++ b/lib/mcp_tool_registry.ml
@@ -83,6 +83,7 @@ let all_handlers_sync : (string * tool_handler_sync) list = [
   ("figma_team", wrap_sync_pure (handle_category "team"));
   ("figma_export", wrap_sync_pure (handle_category "export"));
   ("figma_components", wrap_sync_pure (handle_category "components"));
+  ("figma_code", wrap_sync_pure (handle_category "code"));
 ]
 
 let find_sync_handler name = List.assoc_opt name all_handlers_sync

--- a/test/test_mcp_tools_extra.ml
+++ b/test/test_mcp_tools_extra.ml
@@ -824,14 +824,13 @@ let test_handle_category_call_unknown_tool () =
 
 let test_handle_category_invalid_mode () =
   let args = `Assoc [("mode", `String "invalid_mode")] in
-  (* handle_category raises Invalid_argument for unknown modes *)
-  (try
-     let _result = handle_category "core" args in
-     fail "expected Invalid_argument for invalid mode"
-   with Invalid_argument msg ->
-     check bool "mentions invalid" true
-       (Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid" ||
-        Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid"))
+  (* Invalid mode now returns Error instead of raising *)
+  match handle_category "core" args with
+  | Error msg ->
+      check bool "mentions invalid" true
+        (Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid" ||
+         Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid")
+  | Ok _ -> fail "expected Error for invalid mode"
 
 let test_handle_category_unknown_category () =
   let args = `Assoc [("mode", `String "list")] in

--- a/test/test_mcp_tools_w6.ml
+++ b/test/test_mcp_tools_w6.ml
@@ -1394,18 +1394,11 @@ let test_handle_category_call_parse_url_implicit () =
 
 let test_handle_category_invalid_mode_caught () =
   let args = `Assoc [("mode", `String "execute")] in
-  (* handle_category raises Invalid_argument for unknown modes *)
-  (try
-    match handle_category "core" args with
-    | Error msg ->
-        check bool "mentions invalid" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid" || Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid")
-    | Ok _ -> fail "Expected Error for invalid mode"
-   with
-   | Invalid_argument msg ->
-       check bool "mentions invalid" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid" || Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid")
-   | exn ->
-       (* Other exception: still acceptable, the branch was exercised *)
-       check bool "exception raised" true (String.length (Printexc.to_string exn) > 0))
+  (* Invalid mode now returns Error instead of raising *)
+  match handle_category "core" args with
+  | Error msg ->
+      check bool "mentions invalid" true (Mcp_helpers.string_contains ~haystack:msg ~needle:"invalid" || Mcp_helpers.string_contains ~haystack:msg ~needle:"Invalid")
+  | Ok _ -> fail "Expected Error for invalid mode"
 
 let handle_category_extra_tests = [
   "list all categories", `Quick, test_handle_category_list_all_categories;

--- a/test/test_protocol_a5.ml
+++ b/test/test_protocol_a5.ml
@@ -141,7 +141,7 @@ let test_ipp_get_root () =
   check bool "GET /" false (is_public_path `GET "/")
 
 let test_ipp_get_metrics () =
-  check bool "GET /metrics" false (is_public_path `GET "/metrics")
+  check bool "GET /metrics" true (is_public_path `GET "/metrics")
 
 let test_ipp_post_mcp () =
   check bool "POST /mcp" false (is_public_path `POST "/mcp")

--- a/test/test_protocol_eio_w11.ml
+++ b/test/test_protocol_eio_w11.ml
@@ -324,7 +324,7 @@ let test_ipp_options () = check_b "opt" true (is_public_path `OPTIONS "/x")
 let test_ipp_health () = check_b "health" true (is_public_path `GET "/health")
 let test_ipp_post_h () = check_b "post h" false (is_public_path `POST "/health")
 let test_ipp_get_r () = check_b "get /" false (is_public_path `GET "/")
-let test_ipp_get_m () = check_b "metrics" false (is_public_path `GET "/metrics")
+let test_ipp_get_m () = check_b "metrics" true (is_public_path `GET "/metrics")
 
 (* ---- normalize_env ---- *)
 

--- a/test/test_tools_a5.ml
+++ b/test/test_tools_a5.ml
@@ -409,17 +409,14 @@ let test_category_call_tool_not_found () =
   | Ok _ -> fail "Expected error"
 
 let test_category_invalid_mode () =
-  (* Invalid mode raises Invalid_argument before the try/with block *)
-  let raised = ref false in
-  (try
-    let _ = Mcp_tools.handle_category "core" (`Assoc [
-      ("mode", `String "invalid_mode");
-    ]) in ()
-  with Invalid_argument msg ->
-    raised := true;
+  (* Invalid mode now returns Error instead of raising *)
+  match Mcp_tools.handle_category "core" (`Assoc [
+    ("mode", `String "invalid_mode");
+  ]) with
+  | Error msg ->
     check bool "invalid mode msg" true
-      (try let _ = Str.search_forward (Str.regexp_string "Invalid mode") msg 0 in true with Not_found -> false));
-  check bool "raised Invalid_argument" true !raised
+      (try let _ = Str.search_forward (Str.regexp_string "Invalid mode") msg 0 in true with Not_found -> false)
+  | Ok _ -> fail "expected Error for invalid mode"
 
 let test_category_auto_list () =
   (* No tool, no args => auto-list *)

--- a/test/test_tools_handlers_w9.ml
+++ b/test/test_tools_handlers_w9.ml
@@ -894,14 +894,13 @@ let () =
      mcp_tools.ml: handle_category (edge cases)
      ================================================================= *)
   let test_category_invalid_mode () =
-    (* Invalid mode raises Invalid_argument before try-with catches it *)
-    try
-      ignore (Mcp_tools.handle_category "explore" (`Assoc [("mode", `String "bogus")]));
-      fail "expected Invalid_argument"
-    with Invalid_argument msg ->
-      check bool "says invalid mode" true
-        (try ignore (Str.search_forward (Str.regexp_string "Invalid mode") msg 0); true
-         with Not_found -> false)
+    (* Invalid mode now returns Error instead of raising *)
+    match Mcp_tools.handle_category "explore" (`Assoc [("mode", `String "bogus")]) with
+    | Error msg ->
+        check bool "says invalid mode" true
+          (try ignore (Str.search_forward (Str.regexp_string "Invalid mode") msg 0); true
+           with Not_found -> false)
+    | Ok _ -> fail "expected Error for invalid mode"
   in
 
   let test_category_describe_missing_tool () =


### PR DESCRIPTION
## Summary
- **#151**: `/metrics` 엔드포인트를 `is_public_path`에 추가 (모니터링 시스템 인증 없이 접근)
- **#153**: `code` 카테고리 추가 (`codegen`, `code_connect` 도구 포함)
- **#154**: `mode=call` 시 `args` 미전달 시 flat params fallback 지원
- **#155**: `try` 범위를 `effective_mode` 바인딩까지 확장 (Invalid_argument가 try 밖에서 발생하여 JSON-RPC id 소실되는 버그 수정)
- **#156**: phantom `get_style`을 `components` 카테고리에서 제거
- **#157**: env token 우선 시 명시적 token 무시 경고 로그 추가
- **#152**: wontfix (auth-first는 의도된 보안 설계)

## Changes
- `lib/mcp_protocol_router.ml`: `/metrics` public path 추가
- `lib/mcp_tool_defs.ml`: `get_style` 제거, `code` 카테고리 추가
- `lib/mcp_tool_handlers.ml`: try 범위 확장 + flat params fallback
- `lib/mcp_tool_registry.ml`: `figma_code` 핸들러 등록
- `lib/mcp_helpers.ml`: token 무시 경고 로그
- `lib/mcp_sdk_adapter_figma.ml`: `icon = None` 필드 추가 (upstream compat)
- 6개 테스트 파일: `Invalid_argument` 예외 → `Error` 반환 검증으로 변경

## Test plan
- [x] `dune build` 성공
- [x] `dune test` 전체 통과 (0 failures)
- [ ] HTTP 서버 기동 후 curl 테스트 (`/metrics`, `figma_code`, flat params, invalid mode)

Closes #151, #153, #154, #155, #156
Refs #152, #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)