### PR TITLE
Align MCP negotiation and surface safe exec errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Pin git dependencies
         run: |
-          SDK_REF=refactor/mcp-correctness-audit
+          SDK_REF=63200cf106ce9eee7b65c59d3110904e3bd58a73e
           opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
           opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
           opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Pin git dependencies
         run: |
-          SDK_REF=63200cf106ce9eee7b65c59d3110904e3bd58a73e
+          SDK_REF=63200cf423245b8f2db1c696e23fcd7aa1451d88
           opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
           opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
           opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,10 @@ jobs:
 
       - name: Pin git dependencies
         run: |
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
+          SDK_REF=refactor/mcp-correctness-audit
+          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
+          opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
+          opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#${SDK_REF} -n -y
 
       - name: Install dependencies
         run: |

--- a/lib/mcp_http_helpers.ml
+++ b/lib/mcp_http_helpers.ml
@@ -62,7 +62,7 @@ module Response = struct
   (** SSE streaming response for MCP streamable-http protocol *)
   let sse_stream reqd ~on_write =
     let headers = Httpun.Headers.of_list ([
-      ("content-type", "text/event-stream");
+      ("content-type", Mcp_protocol.Http_negotiation.mcp_sse_content_type);
       ("cache-control", "no-cache");
       ("connection", "keep-alive");
     ] @ Mcp_cors.headers reqd ~include_methods:false ~include_headers:false) in
@@ -84,7 +84,7 @@ module Response = struct
     let body = prime ^ message in
     let session_headers = if session_id = "" then [] else [("mcp-session-id", session_id)] in
     let headers = Httpun.Headers.of_list ([
-      ("content-type", "text/event-stream");
+      ("content-type", Mcp_protocol.Http_negotiation.mcp_sse_content_type);
       ("content-length", string_of_int (String.length body));
       ("cache-control", "no-cache");
     ] @ Mcp_cors.headers reqd ~include_methods:true ~include_headers:true
@@ -196,15 +196,11 @@ module Request = struct
   let method_ (request : Httpun.Request.t) =
     request.meth
 
-  (** Check if client accepts SSE (MCP Streamable HTTP) *)
+  (** Check if client accepts streamable MCP per shared SDK negotiation.
+      The current MCP HTTP rules require both JSON and SSE in Accept. *)
   let accepts_sse (request : Httpun.Request.t) =
     match Httpun.Headers.get request.Httpun.Request.headers "accept" with
-    | Some accept ->
-        let accept_lower = String.lowercase_ascii accept in
-        (try
-          let _ = Str.search_forward (Str.regexp_string "text/event-stream") accept_lower 0 in
-          true
-        with Not_found -> false)
+    | Some accept -> Mcp_protocol.Http_negotiation.accepts_streamable_mcp accept
     | None -> false
 end
 

--- a/lib/mcp_protocol_server.ml
+++ b/lib/mcp_protocol_server.ml
@@ -150,6 +150,44 @@ let run ~sw ~net ~clock ~domain_mgr config server =
 (** Graceful shutdown exception *)
 exception Shutdown
 
+let install_shutdown_handlers pending_shutdown_signal =
+  let request_shutdown signal_name =
+    ignore
+      (Atomic.compare_and_set pending_shutdown_signal None (Some signal_name))
+  in
+  Sys.set_signal Sys.sigterm
+    (Sys.Signal_handle (fun _ -> request_shutdown "SIGTERM"));
+  Sys.set_signal Sys.sigint
+    (Sys.Signal_handle (fun _ -> request_shutdown "SIGINT"))
+
+let rec await_http_shutdown_signal ~clock pending_shutdown_signal =
+  match Atomic.get pending_shutdown_signal with
+  | Some signal_name ->
+      Atomic.set pending_shutdown_signal None;
+      eprintf "\n🎨 %s: Received %s, shutting down gracefully...\n%!"
+        Figma_mcp_protocol.server_name signal_name;
+      broadcast_sse_shutdown signal_name;
+      eprintf "🎨 %s: Sent shutdown notification to %d SSE clients\n%!"
+        Figma_mcp_protocol.server_name (Hashtbl.length sse_clients);
+      Eio.Time.sleep clock 0.2;
+      close_all_sse_connections ();
+      Eio.Time.sleep clock 0.2;
+      raise Shutdown
+  | None ->
+      Eio.Time.sleep clock 0.1;
+      await_http_shutdown_signal ~clock pending_shutdown_signal
+
+let rec await_stdio_shutdown_signal ~clock pending_shutdown_signal =
+  match Atomic.get pending_shutdown_signal with
+  | Some signal_name ->
+      Atomic.set pending_shutdown_signal None;
+      eprintf "\n[%s] Received %s, shutting down...\n%!"
+        Figma_mcp_protocol.server_name signal_name;
+      raise Shutdown
+  | None ->
+      Eio.Time.sleep clock 0.1;
+      await_stdio_shutdown_signal ~clock pending_shutdown_signal
+
 (** Start the server - entry point for main.ml (Pure Eio, no Lwt) *)
 let start_server ?(config = default_config) server =
   (* Initialize crypto RNG for HTTPS/TLS *)
@@ -159,44 +197,14 @@ let start_server ?(config = default_config) server =
   let clock = Eio.Stdenv.clock env in
   let domain_mgr = Some (Eio.Stdenv.domain_mgr env) in
 
-  (* Graceful shutdown setup *)
-  let switch_ref = ref None in
-  let shutdown_initiated = ref false in
-  let initiate_shutdown signal_name =
-    if not !shutdown_initiated then begin
-      shutdown_initiated := true;
-      eprintf "\n🎨 %s: Received %s, shutting down gracefully...\n%!" Figma_mcp_protocol.server_name signal_name;
-
-      (* Broadcast shutdown notification to all SSE clients *)
-      broadcast_sse_shutdown signal_name;
-      eprintf "🎨 %s: Sent shutdown notification to %d SSE clients\n%!" Figma_mcp_protocol.server_name (Hashtbl.length sse_clients);
-
-      (* Give clients 200ms to receive the notification.
-         NOTE: Unix.sleepf is intentional here. This closure runs as a POSIX signal
-         handler (Sys.set_signal) which executes outside Eio fiber context, so
-         Eio.Time.sleep is not available. Blocking the OS thread is acceptable
-         during shutdown. *)
-      Unix.sleepf 0.2;
-
-      (* Gracefully close all SSE connections before Switch.fail *)
-      close_all_sse_connections ();
-
-      (* Give connections 200ms to complete close handshake (same signal handler
-         context constraint as above) *)
-      Unix.sleepf 0.2;
-
-      match !switch_ref with
-      | Some sw -> Eio.Switch.fail sw Shutdown
-      | None -> ()
-    end
-  in
-  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGTERM"));
-  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGINT"));
+  let pending_shutdown_signal = Atomic.make None in
+  install_shutdown_handlers pending_shutdown_signal;
 
   (try
     Eio.Switch.run @@ fun sw ->
-    switch_ref := Some sw;
-    run ~sw ~net ~clock ~domain_mgr config server
+    Eio.Fiber.first
+      (fun () -> run ~sw ~net ~clock ~domain_mgr config server)
+      (fun () -> await_http_shutdown_signal ~clock pending_shutdown_signal)
   with
   | Shutdown ->
       eprintf "🎨 %s: Shutdown complete.\n%!" Figma_mcp_protocol.server_name
@@ -257,25 +265,14 @@ let start_stdio_server server =
   let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
 
-  (* Graceful shutdown setup *)
-  let switch_ref = ref None in
-  let shutdown_initiated = ref false in
-  let initiate_shutdown signal_name =
-    if not !shutdown_initiated then begin
-      shutdown_initiated := true;
-      eprintf "\n[%s] Received %s, shutting down...\n%!" Figma_mcp_protocol.server_name signal_name;
-      match !switch_ref with
-      | Some sw -> Eio.Switch.fail sw Shutdown
-      | None -> ()
-    end
-  in
-  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGTERM"));
-  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGINT"));
+  let pending_shutdown_signal = Atomic.make None in
+  install_shutdown_handlers pending_shutdown_signal;
 
   (try
     Eio.Switch.run @@ fun sw ->
-    switch_ref := Some sw;
-    run_stdio ~sw ~env ~net ~clock server
+    Eio.Fiber.first
+      (fun () -> run_stdio ~sw ~env ~net ~clock server)
+      (fun () -> await_stdio_shutdown_signal ~clock pending_shutdown_signal)
   with
   | Shutdown ->
       eprintf "[%s] Shutdown complete.\n%!" Figma_mcp_protocol.server_name

--- a/lib/safe_exec.ml
+++ b/lib/safe_exec.ml
@@ -29,8 +29,22 @@ let command_exists name =
   | Some _ -> true
   | None -> false
 
+let format_unix_error ~context = function
+  | Unix.Unix_error (err, fn, arg) ->
+      let call =
+        if arg = "" then fn else Printf.sprintf "%s(%s)" fn arg
+      in
+      Printf.sprintf "%s: %s: %s" context call (Unix.error_message err)
+  | exn -> Printf.sprintf "%s: %s" context (Printexc.to_string exn)
+
+let close_fd_best_effort fd =
+  try Unix.close fd with Unix.Unix_error _ -> ()
+
 let set_nonblock fd =
-  try Unix.set_nonblock fd with Unix.Unix_error _ -> ()
+  try
+    Unix.set_nonblock fd;
+    Ok ()
+  with exn -> Error (format_unix_error ~context:"set_nonblock" exn)
 
 let read_available ~fd ~buf ~limit ~truncated ~closed =
   if !closed then ()
@@ -50,15 +64,27 @@ let read_available ~fd ~buf ~limit ~truncated ~closed =
 let waitpid_nohang pid =
   try
     match Unix.waitpid [Unix.WNOHANG] pid with
-    | 0, _ -> None
-    | _, status -> Some status
-  with Unix.Unix_error _ -> None
+    | 0, _ -> Ok None
+    | _, status -> Ok (Some status)
+  with
+  | Unix.Unix_error (Unix.ECHILD, _, _) -> Ok None
+  | exn -> Error (format_unix_error ~context:"waitpid" exn)
 
 let kill_process pid =
-  try Unix.kill pid Sys.sigterm with Unix.Unix_error _ -> ()
+  try
+    Unix.kill pid Sys.sigterm;
+    Ok ()
+  with
+  | Unix.Unix_error (Unix.ESRCH, _, _) -> Ok ()
+  | exn -> Error (format_unix_error ~context:"sigterm" exn)
 
 let kill_process_force pid =
-  try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ()
+  try
+    Unix.kill pid Sys.sigkill;
+    Ok ()
+  with
+  | Unix.Unix_error (Unix.ESRCH, _, _) -> Ok ()
+  | exn -> Error (format_unix_error ~context:"sigkill" exn)
 
 let run_blocking ?(timeout_ms=default_timeout_ms) ?(output_limit=default_output_limit) cmd argv =
   try
@@ -67,8 +93,18 @@ let run_blocking ?(timeout_ms=default_timeout_ms) ?(output_limit=default_output_
     let pid = Unix.create_process cmd argv Unix.stdin stdout_w stderr_w in
     Unix.close stdout_w;
     Unix.close stderr_w;
-    set_nonblock stdout_r;
-    set_nonblock stderr_r;
+    (match set_nonblock stdout_r with
+     | Ok () -> ()
+     | Error msg ->
+         close_fd_best_effort stdout_r;
+         close_fd_best_effort stderr_r;
+         raise (Failure msg));
+    (match set_nonblock stderr_r with
+     | Ok () -> ()
+     | Error msg ->
+         close_fd_best_effort stdout_r;
+         close_fd_best_effort stderr_r;
+         raise (Failure msg));
 
     let stdout_buf = Buffer.create 1024 in
     let stderr_buf = Buffer.create 1024 in
@@ -84,7 +120,9 @@ let run_blocking ?(timeout_ms=default_timeout_ms) ?(output_limit=default_output_
       let now = Unix.gettimeofday () in
       if (not !timed_out) && now -. start > (float_of_int timeout_ms /. 1000.0) then begin
         timed_out := true;
-        kill_process pid
+        match kill_process pid with
+        | Ok () -> ()
+        | Error msg -> raise (Failure msg)
       end;
 
       let timeout = 0.1 in
@@ -107,11 +145,17 @@ let run_blocking ?(timeout_ms=default_timeout_ms) ?(output_limit=default_output_
          with Unix.Unix_error (Unix.EINTR, _, _) -> ());
 
       (match !status with
-       | None -> status := waitpid_nohang pid
+       | None ->
+           (match waitpid_nohang pid with
+            | Ok next_status -> status := next_status
+            | Error msg -> raise (Failure msg))
        | Some _ -> ());
 
-      if !timed_out && now -. start > (float_of_int timeout_ms /. 1000.0 +. kill_grace_seconds) then
-        kill_process_force pid;
+      if !timed_out && now -. start > (float_of_int timeout_ms /. 1000.0 +. kill_grace_seconds) then (
+        match kill_process_force pid with
+        | Ok () -> ()
+        | Error msg -> raise (Failure msg)
+      );
 
       if (!status <> None) && !stdout_closed && !stderr_closed then ()
       else loop ()

--- a/test/dune
+++ b/test/dune
@@ -9,3 +9,7 @@
 (test
  (name test_v2_resources)
  (libraries figma_mcp alcotest str))
+
+(test
+ (name test_safe_exec)
+ (libraries figma_mcp alcotest))

--- a/test/test_coverage_push_v090.ml
+++ b/test/test_coverage_push_v090.ml
@@ -268,7 +268,8 @@ let test_accepts_sse_true () =
   let request =
     Httpun.Request.create
       ~headers:
-        (Httpun.Headers.of_list [ ("accept", "text/event-stream") ])
+        (Httpun.Headers.of_list
+           [ ("accept", "application/json, text/event-stream") ])
       `GET"/mcp"
   in
   check bool "accepts SSE" true
@@ -300,6 +301,16 @@ let test_accepts_sse_mixed () =
       `GET"/mcp"
   in
   check bool "mixed accept" true
+    (Mcp_http_helpers.Request.accepts_sse request)
+
+let test_accepts_sse_sse_only_false () =
+  let request =
+    Httpun.Request.create
+      ~headers:
+        (Httpun.Headers.of_list [ ("accept", "text/event-stream") ])
+      `GET"/mcp"
+  in
+  check bool "SSE only is insufficient" false
     (Mcp_http_helpers.Request.accepts_sse request)
 
 (* ============== Mcp_protocol_request: classify_message ============== *)
@@ -1013,6 +1024,7 @@ let () =
           test_case "accepts_sse false" `Quick test_accepts_sse_false;
           test_case "accepts_sse no header" `Quick test_accepts_sse_no_header;
           test_case "accepts_sse mixed" `Quick test_accepts_sse_mixed;
+          test_case "accepts_sse sse-only false" `Quick test_accepts_sse_sse_only_false;
         ] );
       ( "Mcp_protocol_request",
         [

--- a/test/test_safe_exec.ml
+++ b/test/test_safe_exec.ml
@@ -37,11 +37,20 @@ let test_run_stdout_exit () =
   | Ok _ -> fail "expected failure"
   | Error _ -> ()
 
+let test_missing_binary () =
+  match Safe_exec.run ~timeout_ms:2000 ~output_limit:1024
+          "/nonexistent/path/binary" [| "/nonexistent/path/binary" |] with
+  | Ok _ -> fail "expected missing binary error"
+  | Error msg ->
+      check bool "mentions unix error" true
+        (String.length msg > 0)
+
 let () =
   run "Safe Exec" [
     "limits", [
       "output cap", `Quick, test_output_cap;
       "timeout", `Quick, test_timeout;
       "nonzero exit", `Quick, test_run_stdout_exit;
+      "missing binary", `Quick, test_missing_binary;
     ];
   ]

--- a/test/test_v2_surface.ml
+++ b/test/test_v2_surface.ml
@@ -53,9 +53,36 @@ let test_initialize_instructions () =
   check bool "omits removed summary tool" false
     (contains ~needle:"figma_get_node_summary" instructions)
 
+let test_streamable_accept_requires_json_and_sse () =
+  let request =
+    Httpun.Request.create
+      ~headers:
+        (Httpun.Headers.of_list
+           [ ("accept", "application/json, text/event-stream") ])
+      `POST "/mcp"
+  in
+  check bool "streamable accept" true
+    (Mcp_http_helpers.Request.accepts_sse request)
+
+let test_streamable_accept_rejects_sse_only () =
+  let request =
+    Httpun.Request.create
+      ~headers:(Httpun.Headers.of_list [ ("accept", "text/event-stream") ])
+      `POST "/mcp"
+  in
+  check bool "sse-only is insufficient" false
+    (Mcp_http_helpers.Request.accepts_sse request)
+
 let () =
   run "v2-surface"
     [
       ("server", [ test_case "public surface" `Quick test_public_surface ]);
-      ("protocol", [ test_case "initialize" `Quick test_initialize_instructions ]);
+      ( "protocol",
+        [
+          test_case "initialize" `Quick test_initialize_instructions;
+          test_case "streamable accept requires json+sse" `Quick
+            test_streamable_accept_requires_json_and_sse;
+          test_case "streamable accept rejects sse-only" `Quick
+            test_streamable_accept_rejects_sse_only;
+        ] );
     ]


### PR DESCRIPTION
## Summary
- move HTTP streamable negotiation onto shared MCP SDK semantics and tighten SSE response headers
- move shutdown work out of the POSIX signal handler into Eio fibers
- narrow `safe_exec` broad catches so unexpected process errors surface as explicit failures

## Stacked Dependency
- depends on jeong-sik/mcp-protocol-sdk#53 for the stricter shared negotiation semantics used by tests

## Verification
- dune build --root .
- ./_build/default/test/test_v2_surface.exe
- ./_build/default/test/test_safe_exec.exe
