### PR TITLE
chore: bump mcp_protocol to >= 1.1.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
  (depends
   (ocaml (>= 5.1))
   (dune (>= 3.13))
-  (mcp_protocol (>= 1.0.0))
+  (mcp_protocol (>= 1.1.0))
   ; Standard dependencies
   (yojson (>= 2.0))
   (uri (>= 4.2))

--- a/figma_mcp.opam
+++ b/figma_mcp.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/jeong-sik/figma-mcp/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.15" & >= "3.13"}
-  "mcp_protocol" {>= "1.0.0"}
+  "mcp_protocol" {>= "1.1.0"}
   "yojson" {>= "2.0"}
   "uri" {>= "4.2"}
   "cmdliner" {>= "1.1"}


### PR DESCRIPTION
## Summary
- Bump `mcp_protocol` version constraint to `>= 1.1.0`
- No dune library changes needed (figma-mcp only uses core `mcp_protocol`)

## Test plan
- [x] Local build passes
- [ ] CI green